### PR TITLE
fix(backend): make CORS allowed origins configurable via env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,7 @@ DB_PASSWORD=ed
 # Backend (Spring Boot)
 # ===================
 SERVER_PORT=8080
+ALLOWED_ORIGINS=http://localhost:3000
 
 # ===================
 # Web (Next.js)

--- a/backend/src/main/java/com/lucasxf/ed/config/CorsProperties.java
+++ b/backend/src/main/java/com/lucasxf/ed/config/CorsProperties.java
@@ -1,0 +1,21 @@
+package com.lucasxf.ed.config;
+
+import java.util.List;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration properties for CORS allowed origins.
+ *
+ * <p>Set {@code ALLOWED_ORIGINS} environment variable in production as a
+ * comma-separated list of allowed origins (e.g., {@code https://app.example.com}).
+ * Defaults to {@code http://localhost:3000} for local development.
+ *
+ * @author Lucas Xavier Ferreira
+ * @since 2026-02-19
+ */
+@ConfigurationProperties(prefix = "cors")
+public record CorsProperties(
+    List<String> allowedOrigins
+) {
+}

--- a/backend/src/main/java/com/lucasxf/ed/security/SecurityConfig.java
+++ b/backend/src/main/java/com/lucasxf/ed/security/SecurityConfig.java
@@ -12,6 +12,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import com.lucasxf.ed.config.CorsProperties;
 
 import java.util.List;
 
@@ -28,9 +29,12 @@ import static java.util.Objects.requireNonNull;
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final CorsProperties corsProperties;
 
-    public SecurityConfig(JwtAuthenticationFilter jwtAuthenticationFilter) {
+    public SecurityConfig(JwtAuthenticationFilter jwtAuthenticationFilter,
+                          CorsProperties corsProperties) {
         this.jwtAuthenticationFilter = requireNonNull(jwtAuthenticationFilter);
+        this.corsProperties = requireNonNull(corsProperties);
     }
 
     @Bean
@@ -69,7 +73,7 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
-        config.setAllowedOrigins(List.of("http://localhost:3000"));
+        config.setAllowedOrigins(corsProperties.allowedOrigins());
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
         config.setAllowedHeaders(List.of("*"));
         config.setAllowCredentials(true);

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -26,6 +26,9 @@ spring:
 server:
   port: ${SERVER_PORT:8080}
 
+cors:
+  allowed-origins: ${ALLOWED_ORIGINS:http://localhost:3000}
+
 auth:
   jwt:
     secret: ${JWT_SECRET:dev-only-secret-change-in-production-must-be-at-least-256-bits-long-for-hs256}

--- a/backend/src/test/java/com/lucasxf/ed/controller/AuthControllerGoogleTest.java
+++ b/backend/src/test/java/com/lucasxf/ed/controller/AuthControllerGoogleTest.java
@@ -1,5 +1,6 @@
 package com.lucasxf.ed.controller;
 
+import com.lucasxf.ed.config.CorsProperties;
 import com.lucasxf.ed.dto.AuthResponse;
 import com.lucasxf.ed.dto.GoogleLoginResponse;
 import com.lucasxf.ed.security.SecurityConfig;
@@ -9,6 +10,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
@@ -31,6 +33,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  */
 @WebMvcTest(AuthController.class)
 @Import(SecurityConfig.class)
+@EnableConfigurationProperties(CorsProperties.class)
 @DisplayName("AuthController — Google OAuth")
 class AuthControllerGoogleTest {
 

--- a/backend/src/test/java/com/lucasxf/ed/controller/AuthControllerTest.java
+++ b/backend/src/test/java/com/lucasxf/ed/controller/AuthControllerTest.java
@@ -1,5 +1,6 @@
 package com.lucasxf.ed.controller;
 
+import com.lucasxf.ed.config.CorsProperties;
 import com.lucasxf.ed.dto.AuthResponse;
 import com.lucasxf.ed.security.SecurityConfig;
 import com.lucasxf.ed.service.AuthService;
@@ -8,6 +9,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
@@ -31,6 +33,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  */
 @WebMvcTest(AuthController.class)
 @Import(SecurityConfig.class)
+@EnableConfigurationProperties(CorsProperties.class)
 @DisplayName("AuthController")
 class AuthControllerTest {
 

--- a/backend/src/test/java/com/lucasxf/ed/controller/HealthControllerTest.java
+++ b/backend/src/test/java/com/lucasxf/ed/controller/HealthControllerTest.java
@@ -1,10 +1,12 @@
 package com.lucasxf.ed.controller;
 
+import com.lucasxf.ed.config.CorsProperties;
 import com.lucasxf.ed.security.SecurityConfig;
 import com.lucasxf.ed.service.JwtService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
@@ -22,6 +24,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  */
 @WebMvcTest(HealthController.class)
 @Import(SecurityConfig.class)
+@EnableConfigurationProperties(CorsProperties.class)
 class HealthControllerTest {
 
     @Autowired

--- a/backend/src/test/java/com/lucasxf/ed/controller/PokControllerTest.java
+++ b/backend/src/test/java/com/lucasxf/ed/controller/PokControllerTest.java
@@ -6,11 +6,13 @@ import com.lucasxf.ed.dto.PokResponse;
 import com.lucasxf.ed.dto.UpdatePokRequest;
 import com.lucasxf.ed.exception.PokAccessDeniedException;
 import com.lucasxf.ed.exception.PokNotFoundException;
+import com.lucasxf.ed.config.CorsProperties;
 import com.lucasxf.ed.security.SecurityConfig;
 import com.lucasxf.ed.service.JwtService;
 import com.lucasxf.ed.service.PokService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Page;
@@ -41,6 +43,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  */
 @WebMvcTest(PokController.class)
 @Import(SecurityConfig.class)
+@EnableConfigurationProperties(CorsProperties.class)
 class PokControllerTest {
 
     @Autowired


### PR DESCRIPTION
## Summary

- Replaced hardcoded `http://localhost:3000` CORS origin in `SecurityConfig` with an environment-driven `CorsProperties` config record
- This unblocks production deployment — the backend can now accept requests from the Vercel domain via `ALLOWED_ORIGINS` env var

## Changes

- `ea361cb` fix(backend): make CORS allowed origins configurable via env var
- `a218d54` Merge pull request #37 from lucasxf/fix/cors-allowed-origins

## Key files

- `backend/src/main/java/com/lucasxf/ed/config/CorsProperties.java` — new `@ConfigurationProperties(prefix = "cors")` record
- `backend/src/main/java/com/lucasxf/ed/security/SecurityConfig.java` — now reads from `CorsProperties` instead of hardcoded string
- `backend/src/main/resources/application.yml` — `cors.allowed-origins: ${ALLOWED_ORIGINS:http://localhost:3000}`
- `backend/src/test/java/.../controller/*Test.java` — added `@EnableConfigurationProperties(CorsProperties.class)` to all `@WebMvcTest` slices
- `.env.example` — documents the new `ALLOWED_ORIGINS` variable

## Testing

- [x] Backend tests passing (125/125)
- [x] Web build passing
- [x] CI green on PR #37 (merged to develop)

## Deployment

Set `ALLOWED_ORIGINS=https://<your-vercel-app>.vercel.app` (comma-separated for multiple origins) in your Railway/Render environment variables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>