### PR TITLE
chore: rebrand to learnimo + deployment infrastructure

### DIFF
--- a/web/src/app/[locale]/page.tsx
+++ b/web/src/app/[locale]/page.tsx
@@ -1,5 +1,5 @@
 import { getTranslations, setRequestLocale } from 'next-intl/server';
-import { Button } from '@/components/ui/Button';
+import Link from 'next/link';
 import { type Locale } from '@/lib/i18n';
 
 interface HomePageProps {
@@ -20,7 +20,12 @@ export default async function HomePage({ params }: HomePageProps) {
       <p className="mb-8 text-lg text-gray-600 dark:text-gray-400">
         {t('description')}
       </p>
-      <Button size="lg">{t('getStarted')}</Button>
+      <Link
+        href={`/${locale}/register`}
+        className="inline-flex h-12 items-center justify-center rounded-md bg-primary-600 px-6 text-lg font-medium text-white transition-colors hover:bg-primary-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
+      >
+        {t('getStarted')}
+      </Link>
     </div>
   );
 }

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -5,7 +5,7 @@
   },
   "home": {
     "welcome": "Welcome to learnimo",
-    "description": "A personal knowledge management tool for engineers.",
+    "description": "Your knowledge journal.",
     "getStarted": "Get Started"
   },
   "theme": {

--- a/web/src/locales/pt-BR.json
+++ b/web/src/locales/pt-BR.json
@@ -5,7 +5,7 @@
   },
   "home": {
     "welcome": "Bem-vindo ao learnimo",
-    "description": "Uma ferramenta de gestão de conhecimento pessoal para engenheiros.",
+    "description": "Seu diário de conhecimento.",
     "getStarted": "Começar"
   },
   "theme": {


### PR DESCRIPTION
## Summary

- Full rebrand from "Engineering Daybook" to **learnimo**
- Pre-deployment fixes: CORS configurable via env var, Supabase SSL connection
- Home page "Get Started" button wired to register page
- Home page description updated to "Your knowledge journal"

## Included PRs

- PR #38 — `fix(backend): make CORS allowed origins configurable via env var`
- PR #41 — `chore: rebrand to learnimo + home page fixes`

## Testing

- [x] Backend: 71 tests passing
- [x] Web: 101/101 tests passing
- [x] Web build: ✓ 16/16 static pages
- [x] Backend live on Railway
- [x] Web live on Vercel (`learnimo-web.vercel.app`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>