### PR TITLE
fix: My Learnings screen — EmptyState on errors, QuickEntry title, label casing

### DIFF
--- a/docs/ROADMAP.phase-1.md
+++ b/docs/ROADMAP.phase-1.md
@@ -97,6 +97,7 @@
 | 1.7.5 | Feed used multi-column grid | ✅ Done (chore/mvp-ux-review) |
 | 1.7.7 | No inline quick-entry (Phase A content-only textarea) | ✅ Done (chore/mvp-ux-review) |
 | 1.7.8 | Google login button styling | ✅ Done (chore/mvp-ux-review) |
+| 1.7.9 | My Learnings screen bug fixes (EmptyState on errors, QuickEntry title field, label casing) | ✅ Done (fix/my-learnings-screen) |
 
 **Remaining:**
 

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "engineering-daybook-web",
+  "name": "learnimo-web",
   "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "engineering-daybook-web",
+      "name": "learnimo-web",
       "version": "0.0.1",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",

--- a/web/src/__tests__/components/poks/PokList.test.tsx
+++ b/web/src/__tests__/components/poks/PokList.test.tsx
@@ -1,20 +1,10 @@
 import { render, screen } from '@testing-library/react';
 import { PokList } from '@/components/poks/PokList';
 import { Pok } from '@/lib/pokApi';
-import { NextIntlClientProvider } from 'next-intl';
 
 vi.mock('next/navigation', () => ({
   useParams: () => ({ locale: 'en' }),
 }));
-
-const messages = {
-  poks: {
-    emptyState: {
-      message: 'No POKs yet. Start capturing what you learn!',
-      cta: 'Create your first POK',
-    },
-  },
-};
 
 describe('PokList', () => {
   const mockPoks: Pok[] = [
@@ -38,45 +28,30 @@ describe('PokList', () => {
     },
   ];
 
-  const renderList = (poks: Pok[]) => {
-    return render(
-      <NextIntlClientProvider locale="en" messages={messages}>
-        <PokList poks={poks} />
-      </NextIntlClientProvider>
-    );
-  };
+  const renderList = (poks: Pok[]) => render(<PokList poks={poks} />);
 
-  it('renders POK cards in a grid layout', () => {
+  it('renders POK cards', () => {
     renderList(mockPoks);
 
     expect(screen.getByRole('heading', { name: 'POK 1' })).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: /Content 2 without title/ })).toBeInTheDocument();
   });
 
-  it('renders multiple POK cards', () => {
+  it('renders one link per POK', () => {
     renderList(mockPoks);
 
-    const links = screen.getAllByRole('link');
-    expect(links).toHaveLength(2);
+    expect(screen.getAllByRole('link')).toHaveLength(2);
   });
 
-  it('shows empty state when no POKs', () => {
-    renderList([]);
+  it('renders nothing when poks is empty', () => {
+    const { container } = renderList([]);
 
-    expect(screen.getByText(/No POKs yet/i)).toBeInTheDocument();
+    expect(container.querySelector('[class*="flex-col"]')).toBeEmptyDOMElement();
   });
 
-  it('shows empty state with create CTA', () => {
-    renderList([]);
-
-    const createLink = screen.getByRole('link', { name: /create/i });
-    expect(createLink).toHaveAttribute('href', expect.stringContaining('/poks/new'));
-  });
-
-  it('renders POK cards in a single-column vertical layout', () => {
+  it('uses a single-column vertical layout', () => {
     const { container } = renderList(mockPoks);
 
-    const list = container.querySelector('[class*="flex-col"]');
-    expect(list).toBeInTheDocument();
+    expect(container.querySelector('[class*="flex-col"]')).toBeInTheDocument();
   });
 });

--- a/web/src/__tests__/components/poks/QuickEntry.test.tsx
+++ b/web/src/__tests__/components/poks/QuickEntry.test.tsx
@@ -1,0 +1,162 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { NextIntlClientProvider } from 'next-intl';
+import { vi } from 'vitest';
+import { QuickEntry } from '@/components/poks/QuickEntry';
+import { pokApi, type Pok } from '@/lib/pokApi';
+
+vi.mock('@/lib/pokApi', () => ({
+  pokApi: { create: vi.fn() },
+}));
+
+vi.mock('@/lib/api', () => ({
+  ApiRequestError: class ApiRequestError extends Error {},
+}));
+
+const messages = {
+  poks: {
+    form: {
+      titleLabel: 'Title',
+      titlePlaceholder: 'Optional - give your learning a title',
+      createButton: 'Save learning',
+    },
+    quickEntry: {
+      placeholder: 'What did you learn?',
+      hint: 'Ctrl+Enter to save',
+      saving: 'Saving...',
+    },
+    errors: {
+      unexpected: 'Something went wrong. Please try again.',
+    },
+  },
+};
+
+const mockCreate = vi.mocked(pokApi.create);
+
+const makePok = (overrides?: Partial<Pok>): Pok => ({
+  id: 'pok-1',
+  userId: 'user-1',
+  title: null,
+  content: 'Some content',
+  deletedAt: null,
+  createdAt: '2026-02-25T10:00:00Z',
+  updatedAt: '2026-02-25T10:00:00Z',
+  ...overrides,
+});
+
+const renderQuickEntry = (onSaved = vi.fn()) =>
+  render(
+    <NextIntlClientProvider locale="en" messages={messages}>
+      <QuickEntry onSaved={onSaved} />
+    </NextIntlClientProvider>
+  );
+
+describe('QuickEntry', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders title input and content textarea', () => {
+    renderQuickEntry();
+
+    expect(screen.getByRole('textbox', { name: /title/i })).toBeInTheDocument();
+    expect(screen.getByRole('textbox', { name: /what did you learn/i })).toBeInTheDocument();
+  });
+
+  it('renders a save button', () => {
+    renderQuickEntry();
+
+    expect(screen.getByRole('button', { name: /save learning/i })).toBeInTheDocument();
+  });
+
+  it('save button is disabled when content is empty', () => {
+    renderQuickEntry();
+
+    expect(screen.getByRole('button', { name: /save learning/i })).toBeDisabled();
+  });
+
+  it('save button is enabled when content has text', async () => {
+    const user = userEvent.setup();
+    renderQuickEntry();
+
+    await user.type(screen.getByRole('textbox', { name: /what did you learn/i }), 'Learned something');
+
+    expect(screen.getByRole('button', { name: /save learning/i })).toBeEnabled();
+  });
+
+  it('calls pokApi.create with content only when no title is provided', async () => {
+    const user = userEvent.setup();
+    const onSaved = vi.fn();
+    mockCreate.mockResolvedValue(makePok());
+    renderQuickEntry(onSaved);
+
+    await user.type(screen.getByRole('textbox', { name: /what did you learn/i }), 'Learned something');
+    await user.click(screen.getByRole('button', { name: /save learning/i }));
+
+    await waitFor(() => {
+      expect(mockCreate).toHaveBeenCalledWith({ title: null, content: 'Learned something' });
+    });
+  });
+
+  it('calls pokApi.create with title and content when both are provided', async () => {
+    const user = userEvent.setup();
+    const onSaved = vi.fn();
+    mockCreate.mockResolvedValue(makePok({ title: 'My Title' }));
+    renderQuickEntry(onSaved);
+
+    await user.type(screen.getByRole('textbox', { name: /title/i }), 'My Title');
+    await user.type(screen.getByRole('textbox', { name: /what did you learn/i }), 'Learned something');
+    await user.click(screen.getByRole('button', { name: /save learning/i }));
+
+    await waitFor(() => {
+      expect(mockCreate).toHaveBeenCalledWith({ title: 'My Title', content: 'Learned something' });
+    });
+  });
+
+  it('clears both fields and calls onSaved after successful save', async () => {
+    const user = userEvent.setup();
+    const onSaved = vi.fn();
+    const savedPok = makePok({ title: 'T', content: 'C' });
+    mockCreate.mockResolvedValue(savedPok);
+    renderQuickEntry(onSaved);
+
+    await user.type(screen.getByRole('textbox', { name: /title/i }), 'T');
+    await user.type(screen.getByRole('textbox', { name: /what did you learn/i }), 'C');
+    await user.click(screen.getByRole('button', { name: /save learning/i }));
+
+    await waitFor(() => {
+      expect(onSaved).toHaveBeenCalledWith(savedPok);
+    });
+
+    expect(screen.getByRole('textbox', { name: /title/i })).toHaveValue('');
+    expect(screen.getByRole('textbox', { name: /what did you learn/i })).toHaveValue('');
+  });
+
+  it('shows an error when pokApi.create fails', async () => {
+    const user = userEvent.setup();
+    mockCreate.mockRejectedValue(new Error('Server error'));
+    renderQuickEntry();
+
+    await user.type(screen.getByRole('textbox', { name: /what did you learn/i }), 'Something');
+    await user.click(screen.getByRole('button', { name: /save learning/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+    });
+  });
+
+  it('submits on Ctrl+Enter in the textarea', async () => {
+    const user = userEvent.setup();
+    const onSaved = vi.fn();
+    mockCreate.mockResolvedValue(makePok());
+    renderQuickEntry(onSaved);
+
+    const textarea = screen.getByRole('textbox', { name: /what did you learn/i });
+    await user.type(textarea, 'Learned something');
+    await user.keyboard('{Control>}{Enter}{/Control}');
+
+    await waitFor(() => {
+      expect(mockCreate).toHaveBeenCalled();
+    });
+  });
+});

--- a/web/src/__tests__/pages/PoksListPage.test.tsx
+++ b/web/src/__tests__/pages/PoksListPage.test.tsx
@@ -65,14 +65,10 @@ describe('PoksListPage', () => {
     expect(document.querySelector('svg.animate-spin')).toBeInTheDocument();
   });
 
-  it('renders the page heading and create button', async () => {
+  it('renders the page heading', async () => {
     mockGetAll.mockResolvedValue(makePage([]));
     renderPoksPage();
     await waitFor(() => expect(screen.getByRole('heading', { name: /my learnings/i })).toBeInTheDocument());
-    expect(screen.getByRole('link', { name: /new learning/i })).toHaveAttribute(
-      'href',
-      '/en/poks/new'
-    );
   });
 
   it('shows empty state when no learnings exist', async () => {
@@ -118,5 +114,15 @@ describe('PoksListPage', () => {
     await waitFor(() => {
       expect(screen.getByRole('alert')).toBeInTheDocument();
     });
+  });
+
+  it('does not show empty state when the API fails', async () => {
+    mockGetAll.mockRejectedValue(new Error('Network error'));
+    renderPoksPage();
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+    });
+    expect(screen.queryByText(/no learnings yet/i)).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /create your first learning/i })).not.toBeInTheDocument();
   });
 });

--- a/web/src/app/[locale]/poks/page.tsx
+++ b/web/src/app/[locale]/poks/page.tsx
@@ -3,7 +3,6 @@
 import { Suspense, useEffect, useState, useCallback } from 'react';
 import { useTranslations } from 'next-intl';
 import { useParams, useRouter, useSearchParams } from 'next/navigation';
-import Link from 'next/link';
 import { PokList } from '@/components/poks/PokList';
 import { QuickEntry } from '@/components/poks/QuickEntry';
 import { SearchBar } from '@/components/poks/SearchBar';
@@ -11,7 +10,6 @@ import { SortDropdown, type SortOption } from '@/components/poks/SortDropdown';
 import { NoSearchResults } from '@/components/poks/NoSearchResults';
 import { pokApi, type Pok, type PokSearchParams } from '@/lib/pokApi';
 import { ApiRequestError } from '@/lib/api';
-import { Button } from '@/components/ui/Button';
 import { Spinner } from '@/components/ui/Spinner';
 import { EmptyState } from '@/components/poks/EmptyState';
 import { Toast } from '@/components/ui/Toast';
@@ -136,18 +134,18 @@ function PoksContent() {
   const hasSearchOrFilter = !!keyword;
   const isEmptyResults = !loading && poks.length === 0;
   const showNoResults = isEmptyResults && hasSearchOrFilter;
-  const showEmptyState = isEmptyResults && !hasSearchOrFilter;
+  // Only show empty state when the list is genuinely empty — not when an API error occurred.
+  // An API error (401, 500, network) leaves poks=[] which would otherwise show the empty
+  // state, making the user think their data is gone.
+  const showEmptyState = isEmptyResults && !hasSearchOrFilter && !error;
 
   return (
     <div className="mx-auto max-w-7xl py-8">
       {/* Header */}
-      <div className="mb-6 flex items-center justify-between">
+      <div className="mb-6">
         <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100">
           {t('list.title')}
         </h1>
-        <Link href={`/${params.locale}/poks/new` as never}>
-          <Button>{t('list.createButton')}</Button>
-        </Link>
       </div>
 
       {/* Inline quick-entry */}
@@ -182,9 +180,9 @@ function PoksContent() {
         <NoSearchResults onClearSearch={handleClearSearch} />
       ) : showEmptyState ? (
         <EmptyState />
-      ) : (
+      ) : poks.length > 0 ? (
         <PokList poks={poks} />
-      )}
+      ) : null}
 
       {/* Results count (when not loading and has results) */}
       {!loading && poks.length > 0 && (

--- a/web/src/components/poks/PokList.tsx
+++ b/web/src/components/poks/PokList.tsx
@@ -2,27 +2,20 @@
 
 import { Pok } from '@/lib/pokApi';
 import { PokCard } from './PokCard';
-import { EmptyState } from './EmptyState';
 
 interface PokListProps {
   poks: Pok[];
 }
 
 /**
- * List component for displaying POKs in a responsive grid layout.
+ * List component for displaying POKs in a single-column vertical layout.
  *
- * Features:
- * - Single-column vertical layout (LIFO chronological reading)
- * - Maps POKs to PokCard components
- * - Shows EmptyState when no POKs
+ * Renders POKs as PokCard components in LIFO chronological order.
+ * Empty state handling is the responsibility of the parent page.
  *
  * @param poks array of POKs to display
  */
 export function PokList({ poks }: PokListProps) {
-  if (poks.length === 0) {
-    return <EmptyState />;
-  }
-
   return (
     <div className="flex flex-col gap-4">
       {poks.map((pok) => (

--- a/web/src/components/poks/QuickEntry.tsx
+++ b/web/src/components/poks/QuickEntry.tsx
@@ -21,19 +21,22 @@ interface QuickEntryProps {
  */
 export function QuickEntry({ onSaved }: QuickEntryProps) {
   const t = useTranslations('poks');
+  const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   const handleSave = useCallback(async () => {
-    const trimmed = content.trim();
-    if (!trimmed || saving) return;
+    const trimmedContent = content.trim();
+    if (!trimmedContent || saving) return;
 
     setSaving(true);
     setError(null);
     try {
-      const pok = await pokApi.create({ content: trimmed });
+      const trimmedTitle = title.trim() || null;
+      const pok = await pokApi.create({ title: trimmedTitle, content: trimmedContent });
+      setTitle('');
       setContent('');
       onSaved(pok);
     } catch (err) {
@@ -46,7 +49,7 @@ export function QuickEntry({ onSaved }: QuickEntryProps) {
       setSaving(false);
       textareaRef.current?.focus();
     }
-  }, [content, saving, onSaved, t]);
+  }, [title, content, saving, onSaved, t]);
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent<HTMLTextAreaElement>) => {
@@ -60,6 +63,15 @@ export function QuickEntry({ onSaved }: QuickEntryProps) {
 
   return (
     <div className="mb-6 rounded-lg border border-gray-200 bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-900">
+      <input
+        type="text"
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+        placeholder={t('form.titlePlaceholder')}
+        disabled={saving}
+        className="mb-2 w-full rounded-md border border-gray-200 bg-transparent px-2 py-1.5 text-sm placeholder-gray-400 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500 disabled:opacity-50 dark:border-gray-700 dark:placeholder-gray-500"
+        aria-label={t('form.titleLabel')}
+      />
       <textarea
         ref={textareaRef}
         value={content}

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -95,11 +95,11 @@
   },
   "poks": {
     "create": {
-      "title": "New Learning"
+      "title": "New learning"
     },
     "list": {
       "title": "My Learnings",
-      "createButton": "New Learning",
+      "createButton": "New learning",
       "resultsCount": "{count, plural, =1 {1 learning found} other {# learnings found}}"
     },
     "search": {
@@ -133,7 +133,7 @@
       "updated": "Updated"
     },
     "edit": {
-      "title": "Edit Learning",
+      "title": "Edit learning",
       "cancelButton": "Cancel"
     },
     "form": {
@@ -141,8 +141,8 @@
       "titlePlaceholder": "Optional - give your learning a title",
       "contentLabel": "Content",
       "contentPlaceholder": "What did you learn today?",
-      "createButton": "Save Learning",
-      "updateButton": "Save Changes",
+      "createButton": "Save learning",
+      "updateButton": "Save changes",
       "submitting": "Saving..."
     },
     "quickEntry": {

--- a/web/src/locales/pt-BR.json
+++ b/web/src/locales/pt-BR.json
@@ -95,11 +95,11 @@
   },
   "poks": {
     "create": {
-      "title": "Novo Aprendizado"
+      "title": "Novo aprendizado"
     },
     "list": {
       "title": "Meus Aprendizados",
-      "createButton": "Novo Aprendizado",
+      "createButton": "Novo aprendizado",
       "resultsCount": "{count, plural, =1 {1 aprendizado encontrado} other {# aprendizados encontrados}}"
     },
     "search": {
@@ -133,7 +133,7 @@
       "updated": "Atualizado"
     },
     "edit": {
-      "title": "Editar Aprendizado",
+      "title": "Editar aprendizado",
       "cancelButton": "Cancelar"
     },
     "form": {
@@ -141,8 +141,8 @@
       "titlePlaceholder": "Opcional - dê um título ao seu aprendizado",
       "contentLabel": "Conteúdo",
       "contentPlaceholder": "O que você aprendeu hoje?",
-      "createButton": "Salvar Aprendizado",
-      "updateButton": "Salvar Alterações",
+      "createButton": "Salvar aprendizado",
+      "updateButton": "Salvar alterações",
       "submitting": "Salvando..."
     },
     "quickEntry": {

--- a/web/src/test/page-test-utils.ts
+++ b/web/src/test/page-test-utils.ts
@@ -122,13 +122,18 @@ export const poksMessages = {
       recentlyCreated: 'Recently created',
       firstCreated: 'First created',
     },
+    quickEntry: {
+      placeholder: 'What did you learn?',
+      hint: 'Ctrl+Enter to save',
+      saving: 'Saving...',
+    },
     form: {
       titleLabel: 'Title',
-      titlePlaceholder: 'Optional',
+      titlePlaceholder: 'Optional - give your learning a title',
       contentLabel: 'Content',
       contentPlaceholder: 'What did you learn today?',
-      createButton: 'Save Learning',
-      updateButton: 'Save Changes',
+      createButton: 'Save learning',
+      updateButton: 'Save changes',
       submitting: 'Saving...',
     },
     delete: {


### PR DESCRIPTION
## Summary

- **Critical:** EmptyState was shown when `loadPoks()` failed (401/500/network error left `poks=[]`), making users think their data was gone. Fixed with `!error` guard on `showEmptyState` and constraining `<PokList>` render to `poks.length > 0`.
- **High:** Added optional title input to the QuickEntry inline form — all quick-saved learnings now get a title option, and `pokApi.create()` passes `{ title, content }`.
- **High:** Removed redundant "Novo Aprendizado" header button; QuickEntry with title field covers the same need inline.
- **Low:** Fixed sentence-case capitalization for button/page-title labels in both EN and PT-BR locales.

## Changes

- fix: My Learnings screen — EmptyState on errors, QuickEntry title, label casing

## What changed

| File | Change |
|------|--------|
| `web/src/app/[locale]/poks/page.tsx` | `showEmptyState` guards `!error`; remove `<Link><Button>` header CTA; constrain `PokList` to `poks.length > 0` |
| `web/src/components/poks/QuickEntry.tsx` | Added `title` state + input field; `pokApi.create()` now sends `{ title, content }` |
| `web/src/components/poks/PokList.tsx` | Removed internal `EmptyState` render — page is now the sole owner |
| `web/src/locales/en.json` | Sentence-case: "Save learning", "Save changes", "New learning", "Edit learning" |
| `web/src/locales/pt-BR.json` | Sentence-case: "Salvar aprendizado", "Salvar alterações", "Novo aprendizado", "Editar aprendizado" |
| `web/src/__tests__/components/poks/QuickEntry.test.tsx` | New — 9 tests covering title input, save with/without title, Ctrl+Enter, clear-on-success, error handling |
| `web/src/__tests__/components/poks/PokList.test.tsx` | Removed empty-state tests (responsibility moved to page) |
| `web/src/__tests__/pages/PoksListPage.test.tsx` | Updated heading test; added "does not show empty state on API failure" test |
| `web/src/test/page-test-utils.ts` | Added `quickEntry` messages; updated label strings to sentence case |
| `docs/ROADMAP.phase-1.md` | Added Milestone 1.7.9 tracking this fix |

## Testing

- ✅ ESLint clean
- ✅ Next.js production build clean
- ✅ 186/186 unit tests passing (23 test files, includes 9 new QuickEntry tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>