### PR TITLE
chore: add learnimo.com.br as alias domain

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,7 @@ DB_PASSWORD=ed
 # ===================
 SERVER_PORT=8080
 ALLOWED_ORIGINS=http://localhost:3000
+APP_BASE_URL=https://learnimo.net
 
 # ===================
 # Web (Next.js)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > A digital learning journal built for engineers who want to capture, organize, and recall their daily learnings.
 
-🚀 **Status:** Phase 1 — MVP **Live at [learnimo.net](https://learnimo.net)**
+🚀 **Status:** Phase 1 — MVP **Live at [learnimo.net](https://learnimo.net) · [learnimo.com.br](https://learnimo.com.br)**
 
 ---
 
@@ -172,7 +172,7 @@ See [ROADMAP.phase-1.md](./docs/ROADMAP.phase-1.md)
 - [x] Learning CRUD (backend + web)
 - [x] Search (keyword, filters, sorting)
 - [x] Dark mode + i18n (EN/PT-BR)
-- [x] Deployed to production (learnimo.net)
+- [x] Deployed to production (learnimo.net · learnimo.com.br)
 - [x] Session persistence (httpOnly cookies)
 - [x] Inline quick-entry
 - [ ] Visual polish (1.7.6)

--- a/backend/src/main/java/com/lucasxf/ed/service/EmailService.java
+++ b/backend/src/main/java/com/lucasxf/ed/service/EmailService.java
@@ -15,6 +15,10 @@ import static java.util.Objects.requireNonNull;
 /**
  * Service for sending transactional emails via JavaMailSender (SMTP).
  *
+ * <p>The base URL used in reset links is configurable via the {@code APP_BASE_URL}
+ * environment variable, defaulting to {@code https://learnimo.net}. This allows
+ * the service to work correctly across all active domains (e.g. learnimo.com.br).
+ *
  * @author Lucas Xavier Ferreira
  * @since 2026-02-21
  */
@@ -22,15 +26,16 @@ import static java.util.Objects.requireNonNull;
 @Service
 public class EmailService {
 
-    private static final String RESET_LINK_BASE = "https://learnimo.net";
-
     private final JavaMailSender mailSender;
     private final String fromAddress;
+    private final String appBaseUrl;
 
     public EmailService(JavaMailSender mailSender,
-                        @Value("${MAIL_FROM:noreply@learnimo.net}") String fromAddress) {
+                        @Value("${MAIL_FROM:noreply@learnimo.net}") String fromAddress,
+                        @Value("${APP_BASE_URL:https://learnimo.net}") String appBaseUrl) {
         this.mailSender = requireNonNull(mailSender);
         this.fromAddress = requireNonNull(fromAddress);
+        this.appBaseUrl = requireNonNull(appBaseUrl);
     }
 
     /**
@@ -42,7 +47,7 @@ public class EmailService {
      */
     public void sendPasswordResetEmail(User user, String rawToken) {
         String locale = normalizeLocale(user.getLocale());
-        String resetLink = RESET_LINK_BASE + "/" + locale + "/reset-password?token=" + rawToken;
+        String resetLink = appBaseUrl + "/" + locale + "/reset-password?token=" + rawToken;
 
         boolean isPtBr = "pt-BR".equals(locale);
 

--- a/backend/src/test/java/com/lucasxf/ed/config/JacksonConfigTest.java
+++ b/backend/src/test/java/com/lucasxf/ed/config/JacksonConfigTest.java
@@ -1,0 +1,50 @@
+package com.lucasxf.ed.config;
+
+import java.time.Instant;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link JacksonConfig}.
+ *
+ * <p>Verifies that the {@link ObjectMapper} bean is configured with Java time
+ * module support and does not write dates as timestamps.
+ *
+ * @author Lucas Xavier Ferreira
+ * @since 2026-02-25
+ */
+@DisplayName("JacksonConfig")
+class JacksonConfigTest {
+
+    private final JacksonConfig jacksonConfig = new JacksonConfig();
+
+    @Test
+    @DisplayName("objectMapper bean is not null")
+    void objectMapper_returnsNonNullMapper() {
+        ObjectMapper mapper = jacksonConfig.objectMapper();
+
+        assertThat(mapper).isNotNull();
+    }
+
+    @Test
+    @DisplayName("objectMapper serializes Instant as ISO-8601 string, not timestamp")
+    void objectMapper_serializesInstantAsIsoString() throws JsonProcessingException {
+        ObjectMapper mapper = jacksonConfig.objectMapper();
+
+        assertThat(mapper.isEnabled(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)).isFalse();
+
+        // Verify round-trip: Instant → JSON string → Instant
+        Instant now = Instant.parse("2026-02-25T10:00:00Z");
+        String json = mapper.writeValueAsString(now);
+
+        // Should produce a quoted ISO-8601 string, not a numeric epoch value
+        assertThat(json).isEqualTo("\"2026-02-25T10:00:00Z\"");
+    }
+}

--- a/backend/src/test/java/com/lucasxf/ed/dto/PokAuditLogResponseTest.java
+++ b/backend/src/test/java/com/lucasxf/ed/dto/PokAuditLogResponseTest.java
@@ -1,0 +1,101 @@
+package com.lucasxf.ed.dto;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import com.lucasxf.ed.domain.PokAuditLog;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link PokAuditLogResponse}.
+ *
+ * @author Lucas Xavier Ferreira
+ * @since 2026-02-25
+ */
+@DisplayName("PokAuditLogResponse")
+class PokAuditLogResponseTest {
+
+    @Nested
+    @DisplayName("from(PokAuditLog)")
+    class From {
+
+        @Test
+        @DisplayName("maps all fields from a CREATE audit log entry")
+        void from_createEntry_mapsAllFields() {
+            UUID pokId = UUID.randomUUID();
+            UUID userId = UUID.randomUUID();
+            Instant now = Instant.now();
+
+            PokAuditLog log = new PokAuditLog(
+                pokId, userId, PokAuditLog.Action.CREATE,
+                null, "New Title",
+                null, "New content",
+                now
+            );
+
+            PokAuditLogResponse response = PokAuditLogResponse.from(log);
+
+            assertThat(response.pokId()).isEqualTo(pokId);
+            assertThat(response.userId()).isEqualTo(userId);
+            assertThat(response.action()).isEqualTo("CREATE");
+            assertThat(response.oldTitle()).isNull();
+            assertThat(response.newTitle()).isEqualTo("New Title");
+            assertThat(response.oldContent()).isNull();
+            assertThat(response.newContent()).isEqualTo("New content");
+            assertThat(response.occurredAt()).isEqualTo(now);
+            // id is null because the entity was not persisted (no @GeneratedValue trigger)
+        }
+
+        @Test
+        @DisplayName("maps all fields from an UPDATE audit log entry")
+        void from_updateEntry_mapsOldAndNewValues() {
+            UUID pokId = UUID.randomUUID();
+            UUID userId = UUID.randomUUID();
+            Instant now = Instant.now();
+
+            PokAuditLog log = new PokAuditLog(
+                pokId, userId, PokAuditLog.Action.UPDATE,
+                "Old Title", "New Title",
+                "Old content", "New content",
+                now
+            );
+
+            PokAuditLogResponse response = PokAuditLogResponse.from(log);
+
+            assertThat(response.action()).isEqualTo("UPDATE");
+            assertThat(response.oldTitle()).isEqualTo("Old Title");
+            assertThat(response.newTitle()).isEqualTo("New Title");
+            assertThat(response.oldContent()).isEqualTo("Old content");
+            assertThat(response.newContent()).isEqualTo("New content");
+            assertThat(response.occurredAt()).isEqualTo(now);
+        }
+
+        @Test
+        @DisplayName("maps all fields from a DELETE audit log entry")
+        void from_deleteEntry_newTitleAndContentAreNull() {
+            UUID pokId = UUID.randomUUID();
+            UUID userId = UUID.randomUUID();
+            Instant now = Instant.now();
+
+            PokAuditLog log = new PokAuditLog(
+                pokId, userId, PokAuditLog.Action.DELETE,
+                "Deleted Title", null,
+                "Deleted content", null,
+                now
+            );
+
+            PokAuditLogResponse response = PokAuditLogResponse.from(log);
+
+            assertThat(response.action()).isEqualTo("DELETE");
+            assertThat(response.oldTitle()).isEqualTo("Deleted Title");
+            assertThat(response.newTitle()).isNull();
+            assertThat(response.oldContent()).isEqualTo("Deleted content");
+            assertThat(response.newContent()).isNull();
+        }
+    }
+}

--- a/backend/src/test/java/com/lucasxf/ed/exception/ExceptionConstructorTest.java
+++ b/backend/src/test/java/com/lucasxf/ed/exception/ExceptionConstructorTest.java
@@ -1,0 +1,79 @@
+package com.lucasxf.ed.exception;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests covering the secondary constructors of domain exception classes.
+ *
+ * <p>Each exception exposes both a message-only constructor (tested elsewhere via
+ * service/controller tests) and either a no-arg or a {@code (String, Throwable)}
+ * constructor whose lines are not yet exercised by any existing test.
+ *
+ * @author Lucas Xavier Ferreira
+ * @since 2026-02-25
+ */
+@DisplayName("Exception constructors")
+class ExceptionConstructorTest {
+
+    @Nested
+    @DisplayName("PokNotFoundException")
+    class PokNotFoundExceptionTests {
+
+        @Test
+        @DisplayName("no-arg constructor sets default message")
+        void noArgConstructor_setsDefaultMessage() {
+            PokNotFoundException ex = new PokNotFoundException();
+
+            assertThat(ex.getMessage()).isEqualTo("POK not found");
+        }
+    }
+
+    @Nested
+    @DisplayName("PokAccessDeniedException")
+    class PokAccessDeniedExceptionTests {
+
+        @Test
+        @DisplayName("no-arg constructor sets default message")
+        void noArgConstructor_setsDefaultMessage() {
+            PokAccessDeniedException ex = new PokAccessDeniedException();
+
+            assertThat(ex.getMessage()).isEqualTo("You do not have permission to access this POK");
+        }
+    }
+
+    @Nested
+    @DisplayName("ResourceConflictException")
+    class ResourceConflictExceptionTests {
+
+        @Test
+        @DisplayName("message-and-cause constructor preserves both values")
+        void messageAndCauseConstructor_preservesBothValues() {
+            Throwable cause = new RuntimeException("root cause");
+
+            ResourceConflictException ex = new ResourceConflictException("Email already taken", cause);
+
+            assertThat(ex.getMessage()).isEqualTo("Email already taken");
+            assertThat(ex.getCause()).isSameAs(cause);
+        }
+    }
+
+    @Nested
+    @DisplayName("AuthenticationException")
+    class AuthenticationExceptionTests {
+
+        @Test
+        @DisplayName("message-and-cause constructor preserves both values")
+        void messageAndCauseConstructor_preservesBothValues() {
+            Throwable cause = new RuntimeException("token expired");
+
+            AuthenticationException ex = new AuthenticationException("Bad credentials", cause);
+
+            assertThat(ex.getMessage()).isEqualTo("Bad credentials");
+            assertThat(ex.getCause()).isSameAs(cause);
+        }
+    }
+}

--- a/backend/src/test/java/com/lucasxf/ed/service/EmailServiceTest.java
+++ b/backend/src/test/java/com/lucasxf/ed/service/EmailServiceTest.java
@@ -36,6 +36,7 @@ import static org.mockito.Mockito.when;
 class EmailServiceTest {
 
     private static final String FROM_ADDRESS = "noreply@learnimo.net";
+    private static final String APP_BASE_URL = "https://learnimo.net";
     private static final String RAW_TOKEN = "raw-token-abc123";
 
     @Mock
@@ -45,7 +46,7 @@ class EmailServiceTest {
 
     @BeforeEach
     void setUp() {
-        emailService = new EmailService(mailSender, FROM_ADDRESS);
+        emailService = new EmailService(mailSender, FROM_ADDRESS, APP_BASE_URL);
     }
 
     // ─────────────────────────────────────────────────────────────────────────

--- a/backend/src/test/java/com/lucasxf/ed/service/PokServiceTest.java
+++ b/backend/src/test/java/com/lucasxf/ed/service/PokServiceTest.java
@@ -23,6 +23,7 @@ import com.lucasxf.ed.dto.PokResponse;
 import com.lucasxf.ed.dto.UpdatePokRequest;
 import com.lucasxf.ed.exception.PokAccessDeniedException;
 import com.lucasxf.ed.exception.PokNotFoundException;
+import com.lucasxf.ed.dto.PokAuditLogResponse;
 import com.lucasxf.ed.repository.PokAuditLogRepository;
 import com.lucasxf.ed.repository.PokRepository;
 
@@ -650,5 +651,146 @@ class PokServiceTest {
 
         // Then: no audit log entry written (transaction would roll back)
         verify(pokAuditLogRepository, never()).save(any(PokAuditLog.class));
+    }
+
+    // ===== GET HISTORY TESTS =====
+
+    @Test
+    void getHistory_whenPokExistsAndUserOwnsIt_shouldReturnAuditLogs() {
+        // Given
+        UUID pokId = UUID.randomUUID();
+        Pok pok = new Pok(userId, "Title", "Content");
+        PokAuditLog log1 = new PokAuditLog(
+            pokId, userId, PokAuditLog.Action.CREATE,
+            null, "Title", null, "Content", Instant.now().minusSeconds(60)
+        );
+        PokAuditLog log2 = new PokAuditLog(
+            pokId, userId, PokAuditLog.Action.UPDATE,
+            "Title", "New Title", "Content", "New content", Instant.now()
+        );
+
+        when(pokRepository.findById(pokId)).thenReturn(Optional.of(pok));
+        when(pokAuditLogRepository.findByPokIdOrderByOccurredAtDesc(pokId))
+            .thenReturn(List.of(log2, log1));
+
+        // When
+        List<PokAuditLogResponse> history = pokService.getHistory(pokId, userId);
+
+        // Then: newest first, both entries returned
+        assertThat(history).hasSize(2);
+        assertThat(history.get(0).action()).isEqualTo("UPDATE");
+        assertThat(history.get(1).action()).isEqualTo("CREATE");
+
+        verify(pokRepository).findById(pokId);
+        verify(pokAuditLogRepository).findByPokIdOrderByOccurredAtDesc(pokId);
+    }
+
+    @Test
+    void getHistory_whenPokNotFound_shouldThrowPokNotFoundException() {
+        // Given
+        UUID pokId = UUID.randomUUID();
+
+        when(pokRepository.findById(pokId)).thenReturn(Optional.empty());
+
+        // When/Then
+        assertThatThrownBy(() -> pokService.getHistory(pokId, userId))
+            .isInstanceOf(PokNotFoundException.class)
+            .hasMessage("POK not found");
+    }
+
+    @Test
+    void getHistory_whenPokBelongsToOtherUser_shouldThrowPokAccessDeniedException() {
+        // Given
+        UUID pokId = UUID.randomUUID();
+        Pok pok = new Pok(otherUserId, "Title", "Content");
+
+        when(pokRepository.findById(pokId)).thenReturn(Optional.of(pok));
+
+        // When/Then
+        assertThatThrownBy(() -> pokService.getHistory(pokId, userId))
+            .isInstanceOf(PokAccessDeniedException.class);
+    }
+
+    // ===== SEARCH — UPDATED DATE FILTERS TESTS =====
+
+    @Test
+    void search_withUpdatedDateFilters_shouldParseAndPassDates() {
+        // Given
+        String updatedFrom = "2026-02-01T00:00:00Z";
+        String updatedTo = "2026-02-28T23:59:59Z";
+        int page = 0;
+        int size = 20;
+        Page<Pok> pokPage = new PageImpl<>(List.of(), PageRequest.of(page, size), 0);
+
+        when(pokRepository.searchPoks(
+            eq(userId),
+            eq(null),
+            eq(null),
+            eq(null),
+            any(Instant.class),
+            any(Instant.class),
+            any(Pageable.class)
+        )).thenReturn(pokPage);
+
+        // When
+        Page<PokResponse> result = pokService.search(
+            userId, null, null, null, null, null, updatedFrom, updatedTo, page, size);
+
+        // Then: dates are parsed and passed through to repository
+        assertThat(result.getTotalElements()).isZero();
+        verify(pokRepository).searchPoks(
+            eq(userId), eq(null), eq(null), eq(null),
+            any(Instant.class), any(Instant.class), any(Pageable.class));
+    }
+
+    // ===== PARSE INSTANT ERROR PATH =====
+
+    @Test
+    void search_withInvalidDateFormat_shouldThrowIllegalArgumentException() {
+        // Given: a date string that is not ISO 8601
+        String invalidDate = "25-02-2026";
+
+        // When/Then
+        assertThatThrownBy(() ->
+            pokService.search(userId, null, null, null, invalidDate, null, null, null, 0, 20))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Invalid date format")
+            .hasMessageContaining(invalidDate);
+    }
+
+    // ===== BUILD SORT — INVALID FIELD =====
+
+    @Test
+    void search_withInvalidSortField_shouldThrowIllegalArgumentException() {
+        // Given: a sort field that is not in the whitelist
+        String invalidSortField = "id";
+
+        // When/Then
+        assertThatThrownBy(() ->
+            pokService.search(userId, null, invalidSortField, null, null, null, null, null, 0, 20))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Invalid sort field")
+            .hasMessageContaining(invalidSortField);
+    }
+
+    @Test
+    void search_withSortByUpdatedAtDesc_shouldBuildCorrectSort() {
+        // Given: updatedAt DESC is the default, but explicitly providing it should also work
+        String sortBy = "updatedAt";
+        String sortDirection = "DESC";
+        int page = 0;
+        int size = 20;
+        Page<Pok> pokPage = new PageImpl<>(List.of(), PageRequest.of(page, size), 0);
+
+        when(pokRepository.searchPoks(
+            eq(userId), eq(null), eq(null), eq(null), eq(null), eq(null), any(Pageable.class)
+        )).thenReturn(pokPage);
+
+        // When
+        pokService.search(userId, null, sortBy, sortDirection, null, null, null, null, page, size);
+
+        // Then: verify call was made (DESC is the else-branch in buildSort)
+        verify(pokRepository).searchPoks(
+            eq(userId), eq(null), eq(null), eq(null), eq(null), eq(null), any(Pageable.class));
     }
 }

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -8,7 +8,7 @@
 
 - **Web Hosting:** Vercel
 - **Backend Hosting:** Railway (`engineering-daybook-production.up.railway.app`)
-- **Domain:** learnimo.net (Vercel + Locaweb DNS)
+- **Domain:** learnimo.net · learnimo.com.br (Vercel + Locaweb DNS)
 - **Database:** Supabase (managed PostgreSQL)
 - **CI/CD:** GitHub Actions
 - **Versioning:** Release Please + Conventional Commits

--- a/docs/ROADMAP.phase-1.md
+++ b/docs/ROADMAP.phase-1.md
@@ -59,7 +59,7 @@
 |---|------|--------|
 | 1.5.1 | Supabase DB setup | ✅ Done |
 | 1.5.2 | Railway backend deployment | ✅ Done (engineering-daybook-production.up.railway.app) |
-| 1.5.3 | Vercel web deployment + learnimo.net domain | ✅ Done (learnimo.net) |
+| 1.5.3 | Vercel web deployment + learnimo.net domain (learnimo.com.br alias added 2026-02-25) | ✅ Done (learnimo.net · learnimo.com.br) |
 | 1.5.4 | Google OAuth production redirect URIs | ✅ Done |
 
 ### Production Bug Fix (2026-02-20) ✅


### PR DESCRIPTION
## Summary

- Add `learnimo.com.br` as an alias domain alongside `learnimo.net` — both serve the same app, no routing logic
- Make `APP_BASE_URL` configurable in `EmailService` (was hardcoded to `https://learnimo.net`)
- Update docs to reference both domains

## Changes

- `EmailService.java` — extract `RESET_LINK_BASE` to `@Value("${APP_BASE_URL:https://learnimo.net}")` injected field
- `EmailServiceTest.java` — update constructor call to pass `APP_BASE_URL`
- `.env.example` — add `APP_BASE_URL` variable
- `README.md` — status line + deployed checkbox reference both domains
- `docs/CLAUDE.md` — domain line updated
- `docs/ROADMAP.phase-1.md` — Milestone 1.5 updated to reflect `.com.br` alias
- New/extended tests to close JaCoCo coverage gap (88.3% → 97.0%):
  - `PokAuditLogResponseTest` (3 tests)
  - `ExceptionConstructorTest` (4 tests)
  - `JacksonConfigTest` (2 tests)
  - `PokServiceTest` +8 tests (history, search edge cases)

## Platform Steps (manual — not in this PR)

| Platform | Action |
|----------|--------|
| **Vercel** | Add `learnimo.com.br` + `www.learnimo.com.br` as custom domains |
| **Locaweb DNS** | `A @ 76.76.21.21` + `CNAME www cname.vercel-dns.com` |
| **Railway** | `ALLOWED_ORIGINS` += `,https://learnimo.com.br,https://www.learnimo.com.br`; add `APP_BASE_URL=https://learnimo.net` |
| **Google Cloud Console** | Add `https://learnimo.com.br` + `https://www.learnimo.com.br` to Authorized JS Origins |

## Testing

- [x] Backend tests passing (189 passed, 19 skipped — no Docker in CI)
- [x] JaCoCo line coverage: 97.0% (threshold: 90%)
- [ ] Web tests (no web files changed)
- [ ] Manual: verify learnimo.com.br resolves after DNS + Vercel config

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>