### PR TITLE
fix: learnings feed invisible after login in production

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -122,6 +122,10 @@ cd backend
           """;
   ```
 
+- **`SameSite=None` is required for cross-origin cookies (different domains):** When the frontend and backend are on different domains (e.g., learnimo.net on Vercel and railway.app on Railway), `SameSite=Strict` or `SameSite=Lax` will cause the browser to silently block the auth cookie on cross-origin requests — the backend receives no cookie and returns 401 with no body. Fix: use `SameSite=None`. `SameSite=None` **requires** `Secure=true` (HTTPS-only); without it, browsers reject the cookie. In production, set `AUTH_COOKIE_SECURE=true` (or the equivalent env var) in Railway. In local dev (HTTP), `SameSite=Lax` is fine and avoids the `Secure` requirement.
+
+- **`/error` must be in Spring Security `permitAll()`:** Spring dispatches internally to `/error` when an unhandled exception occurs. If `/error` is not in the `permitAll()` list, the security filter chain intercepts the error dispatch and returns a 401 with an empty response body — the actual error information is swallowed. Always include `"/error"` in `requestMatchers(...).permitAll()` in `SecurityConfig`.
+
 ---
 
 ## Testing

--- a/backend/src/main/java/com/lucasxf/ed/security/CookieHelper.java
+++ b/backend/src/main/java/com/lucasxf/ed/security/CookieHelper.java
@@ -12,7 +12,10 @@ import static java.util.Objects.requireNonNull;
 /**
  * Utility for setting and clearing authentication cookies on HTTP responses.
  *
- * <p>Both cookies are {@code HttpOnly} and {@code SameSite=Strict}.
+ * <p>Both cookies are {@code HttpOnly}. The {@code SameSite} policy is derived from the
+ * {@code Secure} flag: {@code SameSite=None} when {@code Secure=true} (production HTTPS),
+ * {@code SameSite=Lax} otherwise (local HTTP dev). Browsers reject {@code SameSite=None}
+ * without {@code Secure}, so the two are always kept in sync.
  * The {@code Secure} flag is controlled by {@code auth.cookie.secure} (set to
  * {@code true} via the {@code AUTH_COOKIE_SECURE} environment variable in production).
  *
@@ -50,11 +53,12 @@ public class CookieHelper {
         long accessMaxAge = authProperties.jwt().accessTokenExpiry().getSeconds();
         long refreshMaxAge = authProperties.jwt().refreshTokenExpiry().getSeconds();
         boolean secure = authProperties.cookie().secure();
+        String sameSite = secure ? "None" : "Lax";
 
         ResponseCookie accessCookie = ResponseCookie.from(ACCESS_TOKEN_COOKIE, accessToken)
             .httpOnly(true)
             .secure(secure)
-            .sameSite("Strict")
+            .sameSite(sameSite)
             .path("/")
             .maxAge(accessMaxAge)
             .build();
@@ -62,7 +66,7 @@ public class CookieHelper {
         ResponseCookie refreshCookie = ResponseCookie.from(REFRESH_TOKEN_COOKIE, refreshToken)
             .httpOnly(true)
             .secure(secure)
-            .sameSite("Strict")
+            .sameSite(sameSite)
             .path(REFRESH_TOKEN_PATH)
             .maxAge(refreshMaxAge)
             .build();
@@ -77,18 +81,21 @@ public class CookieHelper {
      * @param response the HTTP response to clear cookies on
      */
     public void clearAuthCookies(HttpServletResponse response) {
+        boolean secure = authProperties.cookie().secure();
+        String sameSite = secure ? "None" : "Lax";
+
         ResponseCookie clearAccess = ResponseCookie.from(ACCESS_TOKEN_COOKIE, "")
             .httpOnly(true)
-            .secure(authProperties.cookie().secure())
-            .sameSite("Strict")
+            .secure(secure)
+            .sameSite(sameSite)
             .path("/")
             .maxAge(0)
             .build();
 
         ResponseCookie clearRefresh = ResponseCookie.from(REFRESH_TOKEN_COOKIE, "")
             .httpOnly(true)
-            .secure(authProperties.cookie().secure())
-            .sameSite("Strict")
+            .secure(secure)
+            .sameSite(sameSite)
             .path(REFRESH_TOKEN_PATH)
             .maxAge(0)
             .build();

--- a/backend/src/main/java/com/lucasxf/ed/security/SecurityConfig.java
+++ b/backend/src/main/java/com/lucasxf/ed/security/SecurityConfig.java
@@ -48,6 +48,7 @@ public class SecurityConfig {
                 .requestMatchers(
                     "/api/v1/auth/**",
                     "/api/v1/health",
+                    "/error",
                     "/api-docs/**",
                     "/swagger-ui/**",
                     "/swagger-ui.html",

--- a/docs/ROADMAP.phase-1.md
+++ b/docs/ROADMAP.phase-1.md
@@ -75,6 +75,16 @@
 | Disabled Flyway in test profile (`application-test.yml`) | ✅ Done |
 | Fixed HomeCta auth-aware navigation | ✅ Done |
 
+### Production Bug Fix — Learnings Feed Invisible (2026-02-25) ✅
+
+Root cause: three combined bugs prevented logged-in users from seeing their learnings (empty state shown instead of POKs).
+
+| Task | Status |
+|------|--------|
+| `SameSite=Strict` cookie blocked cross-origin requests (learnimo.net → railway.app) — changed to `SameSite=None` in `CookieHelper.java` | ✅ Done |
+| `/error` path not in Spring Security `permitAll()` — caused 401 response with empty body on Spring error dispatch — added to `SecurityConfig.java` | ✅ Done |
+| `!error` falsy check in `page.tsx` treated empty-string error (HTTP/2 always has `statusText=""`) as "no error" — fixed to `error === null` | ✅ Done |
+
 ### Milestone 1.6: Web Testing Quality (partial)
 
 | # | Task | Priority | Status |

--- a/web/CLAUDE.md
+++ b/web/CLAUDE.md
@@ -88,3 +88,9 @@ npm run test     # Run tests (Vitest)
 
 **E2E coverage rule (mandatory):**
 > Every new page, route, or multi-step user flow added to the web app MUST have at least one E2E scenario covering the happy path. This is enforced by `/finish-session` and `/implement-spec`. Exceptions (styling-only, copy changes) must be explicitly stated.
+
+---
+
+## Known Pitfalls
+
+- **Use `=== null` (not `!error`) to check for absence of an error string:** HTTP/2 always delivers an empty `statusText` (`""`), so a fetch error derived from `statusText` will be an empty string. A falsy check (`!error`) treats `""` as "no error", causing the UI to skip the error branch entirely and show empty state instead. Always use strict null checks: `error === null` to mean "no error has occurred", and initialize the state to `null` (not `""`).

--- a/web/src/app/[locale]/poks/page.tsx
+++ b/web/src/app/[locale]/poks/page.tsx
@@ -87,7 +87,7 @@ function PoksContent() {
       setTotalElements(result.totalElements);
     } catch (err) {
       if (err instanceof ApiRequestError) {
-        setError(err.message);
+        setError(err.message || t('errors.unexpected'));
       } else {
         setError(t('errors.unexpected'));
       }
@@ -158,8 +158,10 @@ function PoksContent() {
   const showNoResults = isEmptyResults && hasSearchOrFilter;
   // Only show empty state when the list is genuinely empty — not when an API error occurred.
   // An API error (401, 500, network) leaves poks=[] which would otherwise show the empty
-  // state, making the user think their data is gone.
-  const showEmptyState = isEmptyResults && !hasSearchOrFilter && !error;
+  // state, making the user think their data is gone. Use strict null check so an empty-string
+  // error message (e.g. from HTTP/2 responses where statusText is always "") still blocks
+  // the empty state.
+  const showEmptyState = isEmptyResults && !hasSearchOrFilter && error === null;
 
   return (
     <div className="mx-auto max-w-7xl py-8">


### PR DESCRIPTION
## Summary

- **Root cause fixed:** Logged-in users at learnimo.net couldn't see their learnings — the empty state was shown instead. Three bugs combined to cause this:
  - `SameSite=Strict` cookies were silently blocked cross-origin (learnimo.net → railway.app). Changed to `SameSite=None` (with `Lax` fallback for local dev when `Secure=false`).
  - `/error` missing from Spring Security `permitAll()` — error dispatches were re-intercepted, returning 401 with empty body and no JSON message.
  - `!error` falsy check in `poks/page.tsx` treated HTTP/2's always-empty `statusText` (`""`) as "no error", silently showing the empty state. Fixed to `error === null` with a non-empty fallback.

- **Playwright E2E tests added** (Milestone 1.6.2) — 4 critical user journeys covered: registration, login, feed, quick-entry. Backend fully mocked via `page.route()`.

## Test plan

- [x] Backend `mvn verify` — exit 0, JaCoCo 96.5%
- [x] Web ESLint — clean
- [x] Web Vitest — 186/186 passed
- [x] Web Next.js build — compiled successfully
- [x] CI/CD all green on PR #81
- [ ] Set `AUTH_COOKIE_SECURE=true` in Railway (required for `SameSite=None` to be accepted by browsers in production)
- [ ] Verify learnings appear after login on learnimo.net post-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)