### PR TITLE
fix: production backfill bug — HuggingFace embedding response type

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -182,6 +182,8 @@ cd backend
 
 - **Implementation classes belong in `service.impl`, interfaces in `service`:** The `service` package holds only the interface contracts; concrete implementations go under `service.impl`. Unit tests for an implementation class (`EmbeddingServiceTest`) may stay in the `service` test package but must import the implementation explicitly: `import com.lucasxf.ed.service.impl.HuggingFaceEmbeddingService;`.
 
+- **HuggingFace Inference API for `paraphrase-multilingual-MiniLM-L12-v2` returns a flat `float[]`, not `float[][]`:** The router endpoint (`https://router.huggingface.co/`) returns a single flat vector when the request body is `{"inputs": "text"}`. Use `.body(float[].class)` and return the response directly. Do NOT use `.body(float[][].class)` and index into `response[0]` — the Jackson deserializer will return `null` or throw when the shape is wrong. Symptom: `NullPointerException` or `EmbeddingUnavailableException("HuggingFace returned an empty embedding response")` even when the API returns 200. Other HuggingFace models (e.g., `sentence-transformers` via the direct inference API) may return `float[][]` — always verify the actual response shape for the specific model and endpoint being used.
+
 ---
 
 ## Testing

--- a/backend/src/test/java/com/lucasxf/ed/service/EmbeddingServiceTest.java
+++ b/backend/src/test/java/com/lucasxf/ed/service/EmbeddingServiceTest.java
@@ -79,15 +79,14 @@ class EmbeddingServiceTest {
     }
 
     private void stubSuccessfulEmbedding(float[] vector) {
-        // HF returns float[][] — array of embeddings, one per input
-        float[][] response = {vector};
+        // HF returns float[] — single embedding vector
         when(restClient.post()).thenReturn(requestBodyUriSpec);
         when(requestBodyUriSpec.uri(anyString())).thenReturn(requestBodySpec);
         when(requestBodySpec.header(anyString(), anyString())).thenReturn(requestBodySpec);
         when(requestBodySpec.contentType(any())).thenReturn(requestBodySpec);
         when(requestBodySpec.body(any(Object.class))).thenReturn(requestBodySpec);
         when(requestBodySpec.retrieve()).thenReturn(responseSpec);
-        when(responseSpec.body(float[][].class)).thenReturn(response);
+        when(responseSpec.body(float[].class)).thenReturn(vector);
     }
 
     @Test
@@ -115,15 +114,15 @@ class EmbeddingServiceTest {
         when(requestBodySpec.contentType(any())).thenReturn(requestBodySpec);
         when(requestBodySpec.body(any(Object.class))).thenReturn(requestBodySpec);
         when(requestBodySpec.retrieve()).thenReturn(responseSpec);
-        when(responseSpec.body(float[][].class))
+        when(responseSpec.body(float[].class))
             .thenThrow(new HttpServerErrorException(INTERNAL_SERVER_ERROR))
             .thenThrow(new HttpServerErrorException(INTERNAL_SERVER_ERROR))
-            .thenReturn(new float[][]{expected});
+            .thenReturn(expected);
 
         float[] result = service.embed("text");
 
         assertThat(result[0]).isEqualTo(0.42f);
-        verify(responseSpec, times(3)).body(float[][].class);
+        verify(responseSpec, times(3)).body(float[].class);
     }
 
     @Test
@@ -135,13 +134,13 @@ class EmbeddingServiceTest {
         when(requestBodySpec.contentType(any())).thenReturn(requestBodySpec);
         when(requestBodySpec.body(any(Object.class))).thenReturn(requestBodySpec);
         when(requestBodySpec.retrieve()).thenReturn(responseSpec);
-        when(responseSpec.body(float[][].class))
+        when(responseSpec.body(float[].class))
             .thenThrow(new HttpServerErrorException(INTERNAL_SERVER_ERROR));
 
         assertThatThrownBy(() -> service.embed("text"))
             .isInstanceOf(EmbeddingUnavailableException.class);
 
-        verify(responseSpec, times(3)).body(float[][].class);
+        verify(responseSpec, times(3)).body(float[].class);
     }
 
     @Test
@@ -153,14 +152,14 @@ class EmbeddingServiceTest {
         when(requestBodySpec.contentType(any())).thenReturn(requestBodySpec);
         when(requestBodySpec.body(any(Object.class))).thenReturn(requestBodySpec);
         when(requestBodySpec.retrieve()).thenReturn(responseSpec);
-        when(responseSpec.body(float[][].class))
+        when(responseSpec.body(float[].class))
             .thenThrow(new HttpClientErrorException(BAD_REQUEST));
 
         assertThatThrownBy(() -> service.embed("text"))
             .isInstanceOf(EmbeddingUnavailableException.class);
 
         // Only called once — no retries for 4xx
-        verify(responseSpec, times(1)).body(float[][].class);
+        verify(responseSpec, times(1)).body(float[].class);
     }
 
     @Test
@@ -172,7 +171,7 @@ class EmbeddingServiceTest {
         when(requestBodySpec.contentType(any())).thenReturn(requestBodySpec);
         when(requestBodySpec.body(any(Object.class))).thenReturn(requestBodySpec);
         when(requestBodySpec.retrieve()).thenReturn(responseSpec);
-        when(responseSpec.body(float[][].class))
+        when(responseSpec.body(float[].class))
             .thenThrow(new ResourceAccessException("timeout", new SocketTimeoutException()));
 
         assertThatThrownBy(() -> service.embed("text"))
@@ -188,7 +187,7 @@ class EmbeddingServiceTest {
         when(requestBodySpec.contentType(any())).thenReturn(requestBodySpec);
         when(requestBodySpec.body(any(Object.class))).thenReturn(requestBodySpec);
         when(requestBodySpec.retrieve()).thenReturn(responseSpec);
-        when(responseSpec.body(float[][].class)).thenReturn(new float[0][]);
+        when(responseSpec.body(float[].class)).thenReturn(new float[0]);
 
         assertThatThrownBy(() -> service.embed("text"))
             .isInstanceOf(EmbeddingUnavailableException.class)


### PR DESCRIPTION
## Summary

- **Root fix:** HuggingFace Inference Router for `paraphrase-multilingual-MiniLM-L12-v2` returns a flat `float[]`, not `float[][]`. Every embedding call was failing with a Jackson deserialization error, silently retried 3× then swallowed — making the entire semantic search backfill a no-op in production.
- **Supporting fixes (from PR #88 review):** blank-keyword semantic routing guard, correct `PageImpl` total elements for hybrid and semantic search, removed `ADMIN_INTERNAL_KEY` default, stale dimension references (1536→384) corrected in docs and CLAUDE.md.
- `EmbeddingServiceTest` mocks and assertions updated to match the real API shape.
- `backend/CLAUDE.md` updated with new Known Pitfalls entries.

## Included changes

- fix: correct HuggingFace embedding response type from float[][] to float[]
- fix: address PR #88 Copilot review comments (blank keyword guard, PageImpl totals, ADMIN_INTERNAL_KEY)
- docs: document PageImpl total pitfall in backend/CLAUDE.md

## Test plan

- [x] All unit and integration tests pass
- [x] JaCoCo line coverage: 96.3% (threshold: 90%)
- [ ] Re-trigger backfill in production (`POST /api/v1/admin/embeddings/backfill`) and verify embeddings are generated
- [ ] Confirm semantic search returns relevant results

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>