### PR TITLE
chore: git cleanup + Claude Code review integration (develop → main)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,59 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+  issues:
+    types: [opened, assigned]
+  pull_request:
+    types: [opened, synchronize]
+    branches: [develop, main]
+
+jobs:
+  claude:
+    name: Claude (@mention)
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+
+  review:
+    name: Claude (PR Review)
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: /review
+          claude_args: --max-turns 5

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,8 @@ main ← develop ← feature/xxx
 
 **Main branch protection:** Never push directly to `main`. It is read-only — only pull from it. All code reaches `main` via PRs opened from `develop`. (Added 2026-02-25)
 
+**Branch deletion safety:** Never delete protected, default, or automation-managed branches (`main`, `develop`, `release-please--*`, `copilot/*`, or other CI/CD-managed branches) — even during batch branch cleanup operations. (Added 2026-03-04)
+
 **Commit format (Conventional Commits):**
 ```
 feat: add POK creation endpoint

--- a/docs/ROADMAP.phase-1.md
+++ b/docs/ROADMAP.phase-1.md
@@ -127,6 +127,18 @@ Code quality and correctness fixes addressing 10 review items from PR #104 (deve
 | `.claude/settings.json` | Removed machine-specific absolute paths |
 | `CLAUDE.md` | Added directive: machine-specific paths must go in `settings.local.json`, not `settings.json` |
 
+### Infrastructure / Tooling (chore/git-cleanup, 2026-03-04) ✅
+
+Housekeeping session: GitHub Actions CI tooling added and repository cleaned up.
+
+| Task | Status |
+|------|--------|
+| Investigated Claude GitHub integration — confirmed never set up (repo uses Copilot + Codex for PR reviews) | ✅ Done |
+| Installed Claude Code GitHub Action — created `.github/workflows/claude.yml` using `anthropics/claude-code-action@v1` with auto-PR-review and `@claude` mention support (PR #119 → `develop`) | ✅ Done |
+| Removed 31 local merged branches and 38 remote merged branches | ✅ Done |
+| Deleted 9 stale worktrees | ✅ Done |
+| Added branch-deletion safety directive to `CLAUDE.md` Git Workflow section | ✅ Done |
+
 ---
 
 ## Active / Pending


### PR DESCRIPTION
## Summary

- **Claude Code GitHub Action**: auto-reviews PRs targeting `develop`/`main` and responds to `@claude` mentions in issues/PRs (`anthropics/claude-code-action@v1`)
- **Repository cleanup**: removed 31 local merged branches, 38 remote merged branches, 9 stale worktrees
- **Branch deletion safety directive**: added to `CLAUDE.md` Git Workflow section

## Changes

- chore: add Claude Code review GitHub Action
- docs: add branch deletion safety directive to Git Workflow
- chore: enhance CLAUDE.md with workflow orchestration directives
- docs: record chore/git-cleanup session in ROADMAP.phase-1.md

## Testing

- [ ] CI passing
- [ ] Claude review job triggers on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)