### PR TITLE
chore: git cleanup + Claude Code review integration (develop → main)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -17,10 +17,12 @@ jobs:
   claude:
     name: Claude (@mention)
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      github.actor == 'lucasxf' && (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -39,7 +41,7 @@ jobs:
 
   review:
     name: Claude (PR Review)
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

- **Claude Code GitHub Action**: auto-reviews PRs targeting `develop`/`main`; responds to `@claude` mentions (owner-only gate to prevent quota abuse)
- **Repository cleanup**: removed 31 local merged branches, 38 remote merged branches, 9 stale worktrees
- **Branch deletion safety directive**: added to `CLAUDE.md` Git Workflow section
- **Security hardening**: `@claude` job restricted to `lucasxf` actor; `review` job skips fork PRs

## Changes

- chore: add Claude Code review GitHub Action
- docs: add branch deletion safety directive to Git Workflow
- chore: enhance CLAUDE.md with workflow orchestration directives
- docs: record chore/git-cleanup session in ROADMAP.phase-1.md
- fix: harden Claude workflow against quota abuse and fork secret leak

## Testing

- [ ] CI passing
- [ ] Claude `review` job triggers on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)