### PR TITLE
fix(ci): pin claude-code-action to v1.0.67 on main

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           fetch-depth: 1
 
-      - uses: anthropics/claude-code-action@v1
+      - uses: anthropics/claude-code-action@v1.0.67
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
@@ -54,7 +54,7 @@ jobs:
         with:
           fetch-depth: 1
 
-      - uses: anthropics/claude-code-action@v1
+      - uses: anthropics/claude-code-action@v1.0.67
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: /review


### PR DESCRIPTION
## Summary

- `@v1` on `main` was resolving to `v1.0.68`, which introduced an AJV schema crash (Claude exits with code 1, 0 cost, 488ms)
- `develop` was already pinned to `v1.0.67` to work around this
- The OIDC token exchange (used to post reviews as `claude[bot]`) validates that the workflow file on the PR head branch matches `main` exactly — the version mismatch was causing a 401, blocking Claude reviews on every PR

This aligns `main` with `develop` so PR #122 (and future PRs) can get Claude reviews.

## Next steps

Once `v1.0.68` regression is fixed upstream, revert both branches to `@v1`.

## Test plan

- [ ] Merge this PR
- [ ] Push a commit to `develop` (or re-run the failing workflow on PR #122)
- [ ] Verify "Claude (PR Review)" check passes and `claude[bot]` posts a review

🤖 Generated with [Claude Code](https://claude.com/claude-code)