### PR TITLE
fix: replace ANTHROPIC_API_KEY with claude_code_oauth_token for Max plan auth

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -37,7 +37,7 @@ jobs:
 
       - uses: anthropics/claude-code-action@v1.0.67
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_GITHUB_TOKEN }}
 
   review:
     name: Claude (PR Review)
@@ -56,6 +56,6 @@ jobs:
 
       - uses: anthropics/claude-code-action@v1.0.67
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_GITHUB_TOKEN }}
           prompt: /review
           claude_args: --max-turns 5


### PR DESCRIPTION
## Summary
- Switches Claude Code Action authentication from `ANTHROPIC_API_KEY` (API plan) to `claude_code_oauth_token: CLAUDE_CODE_GITHUB_TOKEN` (Max plan OAuth)
- Fixes CI workflow broken for Max plan subscribers where API key auth is not supported

## Changes
- fix: use claude_code_oauth_token for Max plan auth in CI workflow

## Testing
- [x] Workflow syntax valid
- [x] Secret `CLAUDE_CODE_GITHUB_TOKEN` confirmed present in repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>