### PR TITLE
fix: rename CLAUDE_CODE_GITHUB_TOKEN to CLAUDE_CODE_OAUTH_TOKEN in CI workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -37,7 +37,7 @@ jobs:
 
       - uses: anthropics/claude-code-action@v1.0.67
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_GITHUB_TOKEN }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
   review:
     name: Claude (PR Review)
@@ -56,6 +56,6 @@ jobs:
 
       - uses: anthropics/claude-code-action@v1.0.67
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_GITHUB_TOKEN }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: /review
           claude_args: --max-turns 5


### PR DESCRIPTION
## Summary
- Renames the secret placeholder from `CLAUDE_CODE_GITHUB_TOKEN` to the correct `CLAUDE_CODE_OAUTH_TOKEN` in the Claude Code Action workflow

## Changes
- fix: rename secret placeholder to CLAUDE_CODE_OAUTH_TOKEN

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>