### PR TITLE
feat(mobile): auto-resizing content textarea with larger default size

### DIFF
--- a/docs/ROADMAP.phase-1.md
+++ b/docs/ROADMAP.phase-1.md
@@ -582,7 +582,7 @@ Wave sequencing:
 | Replace skin-tone emojis with neutral symbols | ✅ Done | `fix/avatar-upload` |
 | Tag sort by frequency + collapse/expand top 3 | 🔲 Planned | `feat/tag-sort-collapse` |
 | Social feed: include user's own recent learnings | 🔲 Planned | `feat/social-feed-own-poks` |
-| Auto-resizing + larger content textarea | 🔲 Planned | `feat/auto-resize-textarea` |
+| Auto-resizing + larger content textarea | ✅ Done | `feat/auto-resize-textarea` |
 | Test effectiveness: per-screen enforcement, flow tests, i18n smoke | 🔲 Planned | `chore/test-effectiveness` |
 
 ---

--- a/docs/plans/closed-testing-triage-v1.0.19.md
+++ b/docs/plans/closed-testing-triage-v1.0.19.md
@@ -15,7 +15,7 @@ Closed testing review surfaced 9 product issues (items #1–#9: 2 bugs, 7 featur
 | S3 | #3+#4 Settings persistence | `feat/settings-persistence` | 🔲 Pending | — |
 | S4 | #3+#4 continued (if needed) | `feat/settings-persistence` | 🔲 Pending | — |
 | S5 | #6 Tag sort/collapse | `feat/tag-sort-collapse` | 🔲 Pending | — |
-| S6 | #8+#9 Auto-resize textarea | `feat/auto-resize-textarea` | 🔲 Pending | — |
+| S6 | #8+#9 Auto-resize textarea | `feat/auto-resize-textarea` | ✅ Done | — |
 | S7 | #11 Test effectiveness | `chore/test-effectiveness` | 🔲 Pending | — |
 | S8 | #7 Social feed own POKs | `feat/social-feed-own-poks` | 🔲 Pending | — |
 

--- a/docs/plans/closed-testing-triage-v1.0.19.md
+++ b/docs/plans/closed-testing-triage-v1.0.19.md
@@ -15,7 +15,7 @@ Closed testing review surfaced 9 product issues (items #1–#9: 2 bugs, 7 featur
 | S3 | #3+#4 Settings persistence | `feat/settings-persistence` | 🔲 Pending | — |
 | S4 | #3+#4 continued (if needed) | `feat/settings-persistence` | 🔲 Pending | — |
 | S5 | #6 Tag sort/collapse | `feat/tag-sort-collapse` | 🔲 Pending | — |
-| S6 | #8+#9 Auto-resize textarea | `feat/auto-resize-textarea` | ✅ Done | — |
+| S6 | #8+#9 Auto-resize textarea | `feat/auto-resize-textarea` | ✅ Done | #257 |
 | S7 | #11 Test effectiveness | `chore/test-effectiveness` | 🔲 Pending | — |
 | S8 | #7 Social feed own POKs | `feat/social-feed-own-poks` | 🔲 Pending | — |
 

--- a/mobile/CLAUDE.md
+++ b/mobile/CLAUDE.md
@@ -291,4 +291,23 @@ See `mobile/RELEASE_WORKFLOW.md` for the full step-by-step procedure.
 
   This issue was triggered in `ProfileScreen.test.tsx` when `VisibilityPicker.tsx` was updated to use `Ionicons` icons instead of emoji literals. Any future component that adds an `@expo/vector-icons` import will require the same mock in every screen test file that transitively imports it. (Added 2026-03-28)
 
-*Last updated: 2026-03-28 (session: fix/avatar-upload — S2 closed-testing triage: avatar upload Android 13+ fix verified, skin-tone emojis replaced with Ionicons in VisibilityPicker)*
+- **Auto-resizing `TextInput` pattern — use `onContentSizeChange` with a `useState` height and explicit `minHeight`/`maxHeight`:** For multiline text inputs that should grow with content (e.g., `LearningForm` content field), track height in state and update it via the `onContentSizeChange` callback. Always clamp to a `minHeight` (so the field is usable when empty) and a `maxHeight` (so it does not consume the entire screen). Apply both bounds to the `style` prop.
+
+  ```ts
+  const [contentHeight, setContentHeight] = useState(200);
+
+  <TextInput
+    multiline
+    numberOfLines={10}
+    style={{ minHeight: 200, maxHeight: 400, height: contentHeight }}
+    onContentSizeChange={(e) =>
+      setContentHeight(Math.max(200, e.nativeEvent.contentSize.height))
+    }
+  />
+  ```
+
+  **Testing this pattern:** In component tests (node env, 3rd jest project), assert the `onContentSizeChange` prop exists on the content `TextInput`, invoke it with a synthetic event, and verify the resulting `height` style value equals the clamped result. Do NOT attempt to render with `jest-expo` for this — native content-size events are not fired in the test environment. (Added 2026-04-02)
+
+---
+
+*Last updated: 2026-04-02 (session: feat/auto-resize-textarea — S6 closed-testing triage: items #8+#9 auto-resize textarea + larger default size, 414 tests passing)*

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "learnimo",
     "slug": "learnimo",
-    "version": "1.0.20",
+    "version": "1.0.21",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",

--- a/mobile/src/components/feed/LearningForm.tsx
+++ b/mobile/src/components/feed/LearningForm.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { ScrollView, View } from 'react-native';
 import { useForm, Controller } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -22,6 +22,7 @@ interface Props {
 export function LearningForm({ defaultValues, onSubmit, onCancel, submitLabel, serverError, scrollable = true }: Props) {
   const { theme } = useTheme();
   const { t } = useI18n();
+  const [contentHeight, setContentHeight] = useState(200);
 
   const {
     control,
@@ -70,9 +71,10 @@ export function LearningForm({ defaultValues, onSubmit, onCancel, submitLabel, s
             label={t('learnings.new.contentLabel')}
             placeholder={t('learnings.new.contentPlaceholder')}
             multiline
-            numberOfLines={8}
+            numberOfLines={10}
             textAlignVertical="top"
-            style={{ minHeight: 160 }}
+            style={{ minHeight: 200, height: contentHeight, maxHeight: 400 }}
+            onContentSizeChange={(e) => setContentHeight(Math.max(200, e.nativeEvent.contentSize.height))}
             value={value}
             onChangeText={onChange}
             onBlur={onBlur}

--- a/mobile/src/components/feed/__tests__/LearningForm.test.tsx
+++ b/mobile/src/components/feed/__tests__/LearningForm.test.tsx
@@ -1,0 +1,191 @@
+/**
+ * LearningForm component tests.
+ * Runs in the 'components' jest project (node environment).
+ *
+ * Strategy: call LearningForm(props) as a plain function to get the React element
+ * tree, then traverse to find the content Controller and call its render prop
+ * directly. This covers the auto-resize props without needing a React fiber.
+ *
+ * useState is mocked so the direct function call doesn't trigger "Invalid hook call".
+ * react-hook-form is mocked to avoid its internal hook calls.
+ *
+ * Covers items #8 (auto-resize onContentSizeChange) and #9 (larger default size)
+ * from closed-testing-triage-v1.0.19.
+ */
+import React from 'react';
+
+// ---------------------------------------------------------------------------
+// Module-scope mock state — mock prefix satisfies jest hoisting exception
+// ---------------------------------------------------------------------------
+
+let mockContentHeight = 200;
+let mockSetContentHeight = jest.fn();
+
+// ---------------------------------------------------------------------------
+// Mocks (hoisted before imports by Jest's Babel transform)
+// ---------------------------------------------------------------------------
+
+jest.mock('react', () => {
+  const actual = jest.requireActual('react');
+  return {
+    ...actual,
+    // LearningForm has one useState call: contentHeight (initialized to 200).
+    // Return controlled mock state so we can assert on setter calls.
+    useState: (init: any) => {
+      if (typeof init === 'number') {
+        return [mockContentHeight, mockSetContentHeight];
+      }
+      return [init, jest.fn()];
+    },
+  };
+});
+
+jest.mock('@/contexts/ThemeContext', () => {
+  const { lightTheme } = require('@/theme/tokens');
+  return { useTheme: () => ({ theme: lightTheme }) };
+});
+
+jest.mock('@/contexts/I18nContext', () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}));
+
+jest.mock('react-hook-form', () => ({
+  useForm: () => ({
+    control: {},
+    handleSubmit: (fn: any) => fn,
+    watch: (name: string) => (name === 'content' ? 'some content' : ''),
+    formState: { errors: {}, isSubmitting: false },
+  }),
+  // Controller is stored as a React element type — its function body is NOT called
+  // during direct function invocation. We define it for completeness.
+  Controller: ({ render }: any) =>
+    render({ field: { onChange: jest.fn(), onBlur: jest.fn(), value: '' } }),
+}));
+
+jest.mock('@hookform/resolvers/zod', () => ({ zodResolver: () => ({}) }));
+
+jest.mock('@/lib/validations', () => ({ pokSchema: {} }));
+
+jest.mock('@/components/ui/Button', () => ({ Button: () => null }));
+
+jest.mock('@/components/ui/ErrorMessage', () => ({ ErrorMessage: () => null }));
+
+// ---------------------------------------------------------------------------
+// Imports (after mocks)
+// ---------------------------------------------------------------------------
+
+import { LearningForm } from '../LearningForm';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Traverse the React element tree to find a Controller element by its name prop. */
+function findControllerByName(tree: any, name: string): any {
+  if (!tree || typeof tree !== 'object') return null;
+  if (Array.isArray(tree)) {
+    for (const child of tree) {
+      const found = findControllerByName(child, name);
+      if (found) return found;
+    }
+    return null;
+  }
+  if (tree.props?.name === name) return tree;
+  return findControllerByName(tree.props?.children, name);
+}
+
+/**
+ * Render LearningForm, locate the content Controller, invoke its render prop,
+ * and return the TextInput element's props.
+ */
+function getContentInputProps(overrides: object = {}): any {
+  const element = (LearningForm as any)({
+    onSubmit: jest.fn(),
+    onCancel: jest.fn(),
+    submitLabel: 'Save',
+    ...overrides,
+  });
+  const contentController = findControllerByName(element, 'content');
+  expect(contentController).not.toBeNull();
+  const textInputEl = contentController.props.render({
+    field: { onChange: jest.fn(), onBlur: jest.fn(), value: '' },
+  });
+  return textInputEl.props;
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  mockContentHeight = 200;
+  mockSetContentHeight.mockClear();
+});
+
+// ---------------------------------------------------------------------------
+// Tests — larger default size (#9)
+// ---------------------------------------------------------------------------
+
+describe('LearningForm — content textarea default size (#9)', () => {
+  it('has minHeight 200 (up from 160)', () => {
+    const props = getContentInputProps();
+    expect(props.style.minHeight).toBe(200);
+  });
+
+  it('has numberOfLines 10 (up from 8)', () => {
+    const props = getContentInputProps();
+    expect(props.numberOfLines).toBe(10);
+  });
+
+  it('applies initial contentHeight 200 as height style', () => {
+    const props = getContentInputProps();
+    expect(props.style.height).toBe(200);
+  });
+
+  it('has maxHeight 400 to prevent full-screen takeover', () => {
+    const props = getContentInputProps();
+    expect(props.style.maxHeight).toBe(400);
+  });
+
+  it('has multiline enabled', () => {
+    const props = getContentInputProps();
+    expect(props.multiline).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — auto-resize behavior (#8)
+// ---------------------------------------------------------------------------
+
+describe('LearningForm — auto-resize onContentSizeChange (#8)', () => {
+  it('grows when content size exceeds the current height', () => {
+    const props = getContentInputProps();
+    props.onContentSizeChange({ nativeEvent: { contentSize: { height: 320 } } });
+    expect(mockSetContentHeight).toHaveBeenCalledWith(320);
+  });
+
+  it('floors at 200 when content size is smaller than minHeight', () => {
+    const props = getContentInputProps();
+    props.onContentSizeChange({ nativeEvent: { contentSize: { height: 80 } } });
+    expect(mockSetContentHeight).toHaveBeenCalledWith(200);
+  });
+
+  it('stays at 200 when content size equals minHeight exactly', () => {
+    const props = getContentInputProps();
+    props.onContentSizeChange({ nativeEvent: { contentSize: { height: 200 } } });
+    expect(mockSetContentHeight).toHaveBeenCalledWith(200);
+  });
+
+  it('wires onContentSizeChange to the content TextInput (not the title input)', () => {
+    const props = getContentInputProps();
+    expect(typeof props.onContentSizeChange).toBe('function');
+  });
+
+  it('maxHeight 400 caps visual height when state exceeds it (React Native constraint)', () => {
+    // Simulate state where content grew beyond 400
+    mockContentHeight = 500;
+    const props = getContentInputProps();
+    expect(props.style.height).toBe(500);   // state reflects actual content size
+    expect(props.style.maxHeight).toBe(400); // RN uses maxHeight to cap the rendered height
+  });
+});


### PR DESCRIPTION
## Summary

- Auto-resize `LearningForm` content `TextInput` as the user types — height grows with content and is capped to prevent full-screen takeover
- Larger default size: `minHeight` 160 → 200, `numberOfLines` 8 → 10
- Covers items **#8** (auto-resize `onContentSizeChange`) and **#9** (larger default input size) from the v1.0.19 closed-testing triage

## Changes

- feat(mobile): auto-resizing content textarea with larger default size
- docs: finish-session for feat/auto-resize-textarea (S6 closed-testing triage)

## Testing

- 414 mobile unit tests passing (32 suites)
- 10 new tests cover: minHeight, numberOfLines, initial height, maxHeight, multiline flag, grow/floor/cap behavior of `onContentSizeChange`
- Lint clean

## Documentation

- `mobile/CLAUDE.md` updated with auto-resize pattern and test approach
- `docs/ROADMAP.phase-1.md` milestone item marked ✅ Done
- `docs/plans/closed-testing-triage-v1.0.19.md` S6 row marked ✅ Done
- Mobile version bumped 1.0.20 → 1.0.21

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>