### PR TITLE
feat: tag sort by frequency + collapse/expand top 3

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -299,6 +299,8 @@ cd backend
   private static final byte[] MINIMAL_JPEG = makeJpeg();
   ```
 
+- **`List.of()` with `Object[]` elements requires explicit type witness `List.<Object[]>of(...)`:** Java's type inference resolves `List.of(new Object[]{...})` as `List<Object>`, not `List<Object[]>`. When passing the result to a method typed as `List<Object[]>` (e.g. mocking a repository method that returns `List<Object[]>`), Mockito's `thenReturn()` fails to compile with "no suitable method found". Fix: use the explicit type witness `List.<Object[]>of(new Object[]{tagId, 5L})`. (Added 2026-04-02)
+
 - **Flyway backfill migrations that introduce a new UNIQUE constraint must deduplicate before the bulk UPDATE:** When normalising a column that previously allowed two values to coexist (e.g. `"machine learning"` and `"machine-learning"` were distinct under `LOWER(name)` but both normalise to `"machine-learning"` after a spaces→dashes transform), the bulk `UPDATE` will produce duplicate values and the subsequent `ALTER TABLE … ADD CONSTRAINT … UNIQUE` (or the UPDATE itself if a unique index already exists) will fail with a uniqueness violation — aborting Flyway before startup. Fix: add a dedup step before the bulk UPDATE that (1) elects a winner per collision group using `ROW_NUMBER() OVER (PARTITION BY canonical ORDER BY created_at, id::text)` — **do NOT use `MIN(id)`, as PostgreSQL does not support `MIN()` on UUID columns** (no ordering aggregate registered for that type), (2) reassigns all FK references in every dependent table from loser to winner (using `NOT EXISTS` guards where the target table has a unique index), and (3) deletes the now-orphaned loser rows. Apply this pattern to any backfill that transforms a column used as a unique key. (Added 2026-03-06)
 
 ---

--- a/backend/src/main/java/com/lucasxf/ed/dto/TagResponse.java
+++ b/backend/src/main/java/com/lucasxf/ed/dto/TagResponse.java
@@ -14,6 +14,7 @@ import com.lucasxf.ed.domain.UserTag;
  * @param displayName the display tag name (original casing, dashes)
  * @param color       the user's assigned color for this tag
  * @param createdAt   when the subscription was created
+ * @param pokCount    how many of the user's non-deleted POKs use this tag
  * @author Lucas Xavier Ferreira
  * @since 2026-02-25
  */
@@ -23,21 +24,35 @@ public record TagResponse(
     String name,
     String displayName,
     String color,
-    Instant createdAt) {
+    Instant createdAt,
+    int pokCount) {
 
     /**
-     * Creates a {@link TagResponse} from a {@link UserTag} subscription.
+     * Creates a {@link TagResponse} from a {@link UserTag} subscription with {@code pokCount = 0}.
+     * Use this for single-tag create/rename contexts where frequency is not meaningful.
      *
      * @param userTag the subscription entity
      * @return the response DTO
      */
     public static TagResponse from(UserTag userTag) {
+        return from(userTag, 0);
+    }
+
+    /**
+     * Creates a {@link TagResponse} from a {@link UserTag} subscription with an explicit usage count.
+     *
+     * @param userTag  the subscription entity
+     * @param pokCount how many of the user's non-deleted POKs use this tag
+     * @return the response DTO
+     */
+    public static TagResponse from(UserTag userTag, int pokCount) {
         return new TagResponse(
             userTag.getId(),
             userTag.getTag().getId(),
             userTag.getTag().getName(),
             userTag.getTag().getDisplayName(),
             userTag.getColor(),
-            userTag.getCreatedAt());
+            userTag.getCreatedAt(),
+            pokCount);
     }
 }

--- a/backend/src/main/java/com/lucasxf/ed/repository/PokTagRepository.java
+++ b/backend/src/main/java/com/lucasxf/ed/repository/PokTagRepository.java
@@ -70,4 +70,18 @@ public interface PokTagRepository extends JpaRepository<PokTag, UUID> {
             @Param("oldTagId") UUID oldTagId,
             @Param("newTagId") UUID newTagId,
             @Param("pokIds") List<UUID> pokIds);
+
+    /**
+     * Counts how many non-deleted POKs each tag is assigned to for the given user.
+     * Returns rows of {@code [tagId, count]} for all tags that have at least one assignment.
+     *
+     * @param userId the user's ID
+     * @return list of {@code Object[]} where {@code [0]} is a {@link UUID} tagId
+     *         and {@code [1]} is a {@link Long} count
+     */
+    @Query("SELECT pt.tagId, COUNT(pt) FROM PokTag pt " +
+           "JOIN Pok p ON p.id = pt.pokId " +
+           "WHERE p.userId = :userId AND p.deletedAt IS NULL " +
+           "GROUP BY pt.tagId")
+    List<Object[]> countPoksByTagForUser(@Param("userId") UUID userId);
 }

--- a/backend/src/main/java/com/lucasxf/ed/service/LearnerService.java
+++ b/backend/src/main/java/com/lucasxf/ed/service/LearnerService.java
@@ -210,13 +210,15 @@ public class LearnerService {
                 + pokShareRepository.countBySharedByUserIdAndVisibilityIn(target.getId(), visibleTiers);
         }
 
-        // Pre-fetch the owner's tags once to avoid N+1 queries across the page
+        // Pre-fetch the owner's tags and usage counts once to avoid N+1 queries across the page
         List<UserTag> ownerTags = userTagRepository.findByUserIdAndDeletedAtIsNull(target.getId());
+        Map<UUID, Long> countMap = pokTagRepository.countPoksByTagForUser(target.getId()).stream()
+            .collect(Collectors.toMap(row -> (UUID) row[0], row -> (Long) row[1]));
 
         // Build feed items — owned POKs
         List<FeedItemResponse> feedItems = new ArrayList<>();
         for (Pok pok : poks) {
-            feedItems.add(PokResponse.from(pok, buildTagResponses(pok.getId(), ownerTags), List.of()));
+            feedItems.add(PokResponse.from(pok, buildTagResponses(pok.getId(), ownerTags, countMap), List.of()));
         }
 
         // Append re-learnings (batch-fetch originals to avoid N+1)
@@ -331,18 +333,19 @@ public class LearnerService {
     }
 
     /**
-     * Builds the tag response list for a single POK from a pre-fetched list of the owner's tags.
+     * Builds the tag response list for a single POK from pre-fetched owner tags and usage counts.
      *
      * @param pokId     the POK's ID
      * @param ownerTags the pre-fetched active tags belonging to the POK owner
+     * @param countMap  tag ID → number of non-deleted POKs using that tag (for the owner)
      * @return list of {@link TagResponse} for the POK's assigned tags
      */
-    private List<TagResponse> buildTagResponses(UUID pokId, List<UserTag> ownerTags) {
+    private List<TagResponse> buildTagResponses(UUID pokId, List<UserTag> ownerTags, Map<UUID, Long> countMap) {
         return pokTagRepository.findByPokId(pokId).stream()
             .map(PokTag::getTagId)
             .flatMap(tagId -> ownerTags.stream()
                 .filter(ut -> ut.getTag().getId() != null && ut.getTag().getId().equals(tagId)))
-            .map(TagResponse::from)
+            .map(ut -> TagResponse.from(ut, countMap.getOrDefault(ut.getTag().getId(), 0L).intValue()))
             .toList();
     }
 }

--- a/backend/src/main/java/com/lucasxf/ed/service/LearnerService.java
+++ b/backend/src/main/java/com/lucasxf/ed/service/LearnerService.java
@@ -210,10 +210,14 @@ public class LearnerService {
                 + pokShareRepository.countBySharedByUserIdAndVisibilityIn(target.getId(), visibleTiers);
         }
 
-        // Pre-fetch the owner's tags and usage counts once to avoid N+1 queries across the page
+        // Pre-fetch the owner's tags and usage counts once to avoid N+1 queries across the page.
+        // Non-owner path uses an empty countMap: pokCount leaks the size of private/restricted
+        // activity that the viewer cannot see, so frequency sorting is suppressed for non-owners.
         List<UserTag> ownerTags = userTagRepository.findByUserIdAndDeletedAtIsNull(target.getId());
-        Map<UUID, Long> countMap = pokTagRepository.countPoksByTagForUser(target.getId()).stream()
-            .collect(Collectors.toMap(row -> (UUID) row[0], row -> (Long) row[1]));
+        Map<UUID, Long> countMap = isOwner
+            ? pokTagRepository.countPoksByTagForUser(target.getId()).stream()
+                .collect(Collectors.toMap(row -> (UUID) row[0], row -> (Long) row[1]))
+            : Map.of();
 
         // Build feed items — owned POKs
         List<FeedItemResponse> feedItems = new ArrayList<>();

--- a/backend/src/main/java/com/lucasxf/ed/service/PokService.java
+++ b/backend/src/main/java/com/lucasxf/ed/service/PokService.java
@@ -185,7 +185,8 @@ public class PokService {
         log.debug("Found {} POKs for user {}", poks.getTotalElements(), userId);
 
         List<UserTag> userTags = userTagRepository.findByUserIdAndDeletedAtIsNull(userId);
-        return poks.map(pok -> PokResponse.from(pok, buildTagResponses(pok.getId(), userTags), List.of()));
+        Map<UUID, Long> countMap = buildCountMap(userId);
+        return poks.map(pok -> PokResponse.from(pok, buildTagResponses(pok.getId(), userTags, countMap), List.of()));
     }
 
     /**
@@ -205,6 +206,7 @@ public class PokService {
     @Transactional(readOnly = true)
     public Page<FeedItemResponse> getOwnFeed(UUID userId, int page, int size, String sortBy, String sortDirection) {
         List<UserTag> userTags = userTagRepository.findByUserIdAndDeletedAtIsNull(userId);
+        Map<UUID, Long> countMap = buildCountMap(userId);
 
         // Bounded fetch: load only enough rows to satisfy this page.
         // Fetching top (page+1)*size per source (sorted DESC) guarantees the merged
@@ -229,7 +231,7 @@ public class PokService {
         // Build feed items — owned POKs first
         List<FeedItemResponse> feedItems = new ArrayList<>();
         for (Pok pok : ownedPoks) {
-            feedItems.add(PokResponse.from(pok, buildTagResponses(pok.getId(), userTags), List.of()));
+            feedItems.add(PokResponse.from(pok, buildTagResponses(pok.getId(), userTags, countMap), List.of()));
         }
 
         // Append re-learnings (batch-fetch originals to avoid N+1)
@@ -320,6 +322,7 @@ public class PokService {
             userId, keyword, searchMode, tagId, page, size);
 
         List<UserTag> userTags = userTagRepository.findByUserIdAndDeletedAtIsNull(userId);
+        Map<UUID, Long> countMap = buildCountMap(userId);
 
         // Tag filter takes precedence — bypass semantic search when a tag filter is active.
         // Date-range filters are supported alongside tagId via the combined repository query.
@@ -332,13 +335,13 @@ public class PokService {
             Pageable pageable = PageRequest.of(page, size, sort);
             Page<Pok> poks = pokRepository.findByUserIdAndTagId(userId, tagId,
                 createdFromInstant, createdToInstant, updatedFromInstant, updatedToInstant, pageable);
-            return poks.map(pok -> PokResponse.from(pok, buildTagResponses(pok.getId(), userTags), List.of()));
+            return poks.map(pok -> PokResponse.from(pok, buildTagResponses(pok.getId(), userTags, countMap), List.of()));
         }
 
         boolean hasKeyword = keyword != null && !keyword.isBlank();
         if (hasKeyword && ("semantic".equals(searchMode) || "hybrid".equals(searchMode))) {
             try {
-                return searchWithSemantics(userId, keyword, searchMode, page, size, userTags);
+                return searchWithSemantics(userId, keyword, searchMode, page, size, userTags, countMap);
             } catch (EmbeddingUnavailableException e) {
                 log.warn("Embedding unavailable for search query — falling back to keyword search: {}", e.getMessage());
                 // fall through to keyword search below
@@ -346,7 +349,7 @@ public class PokService {
         }
 
         return keywordSearch(userId, keyword, sortBy, sortDirection, createdFrom, createdTo,
-            updatedFrom, updatedTo, page, size, userTags);
+            updatedFrom, updatedTo, page, size, userTags, countMap);
     }
 
     /**
@@ -354,7 +357,7 @@ public class PokService {
      */
     private Page<PokResponse> searchWithSemantics(
         UUID userId, String keyword, String searchMode,
-        int page, int size, List<UserTag> userTags
+        int page, int size, List<UserTag> userTags, Map<UUID, Long> countMap
     ) {
         String text = (keyword != null && !keyword.isBlank()) ? keyword : "";
         float[] queryEmbedding = embeddingService.embed(text);
@@ -372,7 +375,7 @@ public class PokService {
             List<Pok> merged = mergeSemanticsAndKeyword(semanticPoks, keywordPage.getContent(), size);
             return new PageImpl<>(
                 merged.stream()
-                    .map(pok -> PokResponse.from(pok, buildTagResponses(pok.getId(), userTags), List.of()))
+                    .map(pok -> PokResponse.from(pok, buildTagResponses(pok.getId(), userTags, countMap), List.of()))
                     .toList(),
                 PageRequest.of(page, size),
                 keywordPage.getTotalElements()
@@ -386,7 +389,7 @@ public class PokService {
         List<Pok> pagePoks = semanticPoks.stream().limit(size).toList();
         return new PageImpl<>(
             pagePoks.stream()
-                .map(pok -> PokResponse.from(pok, buildTagResponses(pok.getId(), userTags), List.of()))
+                .map(pok -> PokResponse.from(pok, buildTagResponses(pok.getId(), userTags, countMap), List.of()))
                 .toList(),
             PageRequest.of(page, size),
             approximateTotal
@@ -412,7 +415,7 @@ public class PokService {
         String sortBy, String sortDirection,
         String createdFrom, String createdTo,
         String updatedFrom, String updatedTo,
-        int page, int size, List<UserTag> userTags
+        int page, int size, List<UserTag> userTags, Map<UUID, Long> countMap
     ) {
         Instant createdFromInstant = parseInstant(createdFrom);
         Instant createdToInstant = parseInstant(createdTo);
@@ -426,7 +429,7 @@ public class PokService {
             updatedFromInstant, updatedToInstant, pageable);
 
         log.debug("Found {} POKs matching search criteria for user {}", poks.getTotalElements(), userId);
-        return poks.map(pok -> PokResponse.from(pok, buildTagResponses(pok.getId(), userTags), List.of()));
+        return poks.map(pok -> PokResponse.from(pok, buildTagResponses(pok.getId(), userTags, countMap), List.of()));
     }
 
     /**
@@ -654,9 +657,9 @@ public class PokService {
     }
 
     /**
-     * Builds the tag response list for a single POK, fetching the user's tags from the database.
-     * Use the overload that accepts a pre-fetched {@code userTags} list when processing multiple
-     * POKs in bulk to avoid N+1 queries.
+     * Builds the tag response list for a single POK, fetching the user's tags and counts
+     * from the database. Use the overload that accepts pre-fetched data when processing
+     * multiple POKs in bulk to avoid N+1 queries.
      *
      * @param pokId  the POK's ID
      * @param userId the owner's user ID (used to look up tags)
@@ -664,25 +667,38 @@ public class PokService {
      */
     private List<TagResponse> buildTagResponses(UUID pokId, UUID userId) {
         List<UserTag> userTags = userTagRepository.findByUserIdAndDeletedAtIsNull(userId);
-        return buildTagResponses(pokId, userTags);
+        Map<UUID, Long> countMap = buildCountMap(userId);
+        return buildTagResponses(pokId, userTags, countMap);
     }
 
     /**
-     * Builds the tag response list for a single POK from a pre-fetched list of the user's tags.
-     * Callers that process multiple POKs should fetch {@code userTags} once and pass it here
-     * to avoid issuing one query per POK (N+1 problem).
+     * Builds the tag response list for a single POK from pre-fetched user tags and usage counts.
+     * Callers that process multiple POKs should fetch {@code userTags} and {@code countMap} once
+     * and pass them here to avoid issuing one query per POK (N+1 problem).
      *
-     * @param pokId     the POK's ID
-     * @param userTags  the caller-supplied list of the user's active tags
+     * @param pokId    the POK's ID
+     * @param userTags the caller-supplied list of the user's active tags
+     * @param countMap tag ID → number of non-deleted POKs using that tag (for this user)
      * @return list of {@link TagResponse} for the POK's assigned tags
      */
-    private List<TagResponse> buildTagResponses(UUID pokId, List<UserTag> userTags) {
+    private List<TagResponse> buildTagResponses(UUID pokId, List<UserTag> userTags, Map<UUID, Long> countMap) {
         return pokTagRepository.findByPokId(pokId).stream()
                 .map(PokTag::getTagId)
                 .flatMap(tagId -> userTags.stream()
                         .filter(ut -> ut.getTag().getId() != null && ut.getTag().getId().equals(tagId)))
-                .map(TagResponse::from)
+                .map(ut -> TagResponse.from(ut, countMap.getOrDefault(ut.getTag().getId(), 0L).intValue()))
                 .toList();
+    }
+
+    /**
+     * Fetches tag usage counts for a user as a map from global tag ID to POK count.
+     *
+     * @param userId the user's ID
+     * @return map of tag ID → count of non-deleted POKs using that tag
+     */
+    private Map<UUID, Long> buildCountMap(UUID userId) {
+        return pokTagRepository.countPoksByTagForUser(userId).stream()
+                .collect(Collectors.toMap(row -> (UUID) row[0], row -> (Long) row[1]));
     }
 
     private List<TagSuggestionResponse> buildSuggestionResponses(UUID pokId) {

--- a/backend/src/main/java/com/lucasxf/ed/service/TagService.java
+++ b/backend/src/main/java/com/lucasxf/ed/service/TagService.java
@@ -3,9 +3,11 @@ package com.lucasxf.ed.service;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -121,8 +123,10 @@ public class TagService {
      */
     @Transactional(readOnly = true)
     public List<TagResponse> getUserTags(UUID userId) {
+        Map<UUID, Long> countMap = pokTagRepository.countPoksByTagForUser(userId).stream()
+                .collect(Collectors.toMap(row -> (UUID) row[0], row -> (Long) row[1]));
         return userTagRepository.findByUserIdAndDeletedAtIsNull(userId).stream()
-                .map(TagResponse::from)
+                .map(ut -> TagResponse.from(ut, countMap.getOrDefault(ut.getTag().getId(), 0L).intValue()))
                 .toList();
     }
 

--- a/backend/src/test/java/com/lucasxf/ed/controller/TagControllerTest.java
+++ b/backend/src/test/java/com/lucasxf/ed/controller/TagControllerTest.java
@@ -74,7 +74,7 @@ class TagControllerTest {
     @Test
     void listTags_shouldReturn200WithUserTags() throws Exception {
         // Given
-        TagResponse tag = new TagResponse(tagId, UUID.randomUUID(), "java", "java", "blue", Instant.now());
+        TagResponse tag = new TagResponse(tagId, UUID.randomUUID(), "java", "java", "blue", Instant.now(), 3);
         when(tagService.getUserTags(any())).thenReturn(List.of(tag));
 
         // When/Then
@@ -95,7 +95,7 @@ class TagControllerTest {
     void createTag_withValidRequest_shouldReturn201() throws Exception {
         // Given
         CreateTagRequest request = new CreateTagRequest("spring-boot");
-        TagResponse response = new TagResponse(tagId, UUID.randomUUID(), "spring-boot", "spring-boot", "blue", Instant.now());
+        TagResponse response = new TagResponse(tagId, UUID.randomUUID(), "spring-boot", "spring-boot", "blue", Instant.now(), 0);
         when(tagService.createOrReuse(any(), any())).thenReturn(response);
 
         // When/Then
@@ -126,7 +126,7 @@ class TagControllerTest {
     void renameTag_withValidRequest_shouldReturn200() throws Exception {
         // Given
         UpdateTagRequest request = new UpdateTagRequest("kubernetes");
-        TagResponse response = new TagResponse(tagId, UUID.randomUUID(), "kubernetes", "kubernetes", "purple", Instant.now());
+        TagResponse response = new TagResponse(tagId, UUID.randomUUID(), "kubernetes", "kubernetes", "purple", Instant.now(), 1);
         when(tagService.renameTag(eq(tagId), any(), any())).thenReturn(response);
 
         // When/Then

--- a/backend/src/test/java/com/lucasxf/ed/service/LearnerServiceTest.java
+++ b/backend/src/test/java/com/lucasxf/ed/service/LearnerServiceTest.java
@@ -287,6 +287,7 @@ class LearnerServiceTest {
             .thenReturn(Page.empty());
         when(userTagRepository.findByUserIdAndDeletedAtIsNull(aliceId)).thenReturn(List.of());
         when(pokTagRepository.findByPokId(any(UUID.class))).thenReturn(List.of());
+        when(pokTagRepository.countPoksByTagForUser(aliceId)).thenReturn(List.of());
 
         Page<FeedItemResponse> result = learnerService.getLearnerPoks("alice", bobId, 0, 20);
 
@@ -307,6 +308,7 @@ class LearnerServiceTest {
             .thenReturn(Page.empty());
         when(userTagRepository.findByUserIdAndDeletedAtIsNull(aliceId)).thenReturn(List.of());
         when(pokTagRepository.findByPokId(any(UUID.class))).thenReturn(List.of());
+        when(pokTagRepository.countPoksByTagForUser(aliceId)).thenReturn(List.of());
 
         Page<FeedItemResponse> result = learnerService.getLearnerPoks("alice", bobId, 0, 20);
 

--- a/backend/src/test/java/com/lucasxf/ed/service/PokServiceSemanticSearchTest.java
+++ b/backend/src/test/java/com/lucasxf/ed/service/PokServiceSemanticSearchTest.java
@@ -27,6 +27,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -73,6 +74,7 @@ class PokServiceSemanticSearchTest {
         ReflectionTestUtils.setField(pok1, "id", UUID.randomUUID());
         ReflectionTestUtils.setField(pok2, "id", UUID.randomUUID());
         when(userTagRepository.findByUserIdAndDeletedAtIsNull(userId)).thenReturn(List.of());
+        lenient().when(pokTagRepository.countPoksByTagForUser(any())).thenReturn(List.of());
     }
 
     @Test

--- a/backend/src/test/java/com/lucasxf/ed/service/PokServiceTest.java
+++ b/backend/src/test/java/com/lucasxf/ed/service/PokServiceTest.java
@@ -110,6 +110,7 @@ class PokServiceTest {
         otherUserId = UUID.randomUUID();
         currentUser = new User("alice@example.com", "hash", "Alice", "alice");
         lenient().when(userService.findById(userId)).thenReturn(currentUser);
+        lenient().when(pokTagRepository.countPoksByTagForUser(any())).thenReturn(List.of());
     }
 
     // ===== CREATE POK TESTS =====

--- a/backend/src/test/java/com/lucasxf/ed/service/TagServiceTest.java
+++ b/backend/src/test/java/com/lucasxf/ed/service/TagServiceTest.java
@@ -167,7 +167,9 @@ class TagServiceTest {
         // Given
         Tag tag = new Tag("java", "java");
         UserTag activeTag = new UserTag(userId, tag, "blue");
+        ReflectionTestUtils.setField(tag, "id", UUID.randomUUID());
         when(userTagRepository.findByUserIdAndDeletedAtIsNull(userId)).thenReturn(List.of(activeTag));
+        when(pokTagRepository.countPoksByTagForUser(userId)).thenReturn(List.<Object[]>of(new Object[]{tag.getId(), 5L}));
 
         // When
         List<TagResponse> result = tagService.getUserTags(userId);
@@ -176,12 +178,14 @@ class TagServiceTest {
         assertThat(result).hasSize(1);
         assertThat(result.get(0).name()).isEqualTo("java");
         assertThat(result.get(0).displayName()).isEqualTo("java");
+        assertThat(result.get(0).pokCount()).isEqualTo(5);
     }
 
     @Test
     void getUserTags_withNoTags_shouldReturnEmptyList() {
         // Given
         when(userTagRepository.findByUserIdAndDeletedAtIsNull(userId)).thenReturn(List.of());
+        when(pokTagRepository.countPoksByTagForUser(userId)).thenReturn(List.of());
 
         // When
         List<TagResponse> result = tagService.getUserTags(userId);

--- a/docs/ROADMAP.phase-1.md
+++ b/docs/ROADMAP.phase-1.md
@@ -580,7 +580,7 @@ Wave sequencing:
 | Persist theme + locale settings (backend + contexts) | 🔲 Planned | `feat/settings-persistence` |
 | Profile save UX (feedback on setting changes) | 🔲 Planned | `feat/settings-persistence` |
 | Replace skin-tone emojis with neutral symbols | ✅ Done | `fix/avatar-upload` |
-| Tag sort by frequency + collapse/expand top 3 | 🔲 Planned | `feat/tag-sort-collapse` |
+| Tag sort by frequency + collapse/expand top 3 | ✅ Done | `feat/tag-sort-collapse` |
 | Social feed: include user's own recent learnings | 🔲 Planned | `feat/social-feed-own-poks` |
 | Auto-resizing + larger content textarea | 🔲 Planned | `feat/auto-resize-textarea` |
 | Test effectiveness: per-screen enforcement, flow tests, i18n smoke | 🔲 Planned | `chore/test-effectiveness` |

--- a/docs/plans/closed-testing-triage-v1.0.19.md
+++ b/docs/plans/closed-testing-triage-v1.0.19.md
@@ -14,7 +14,7 @@ Closed testing review surfaced 9 product issues (items #1–#9: 2 bugs, 7 featur
 | S2 | #2 Avatar + #5 Emojis | `fix/avatar-upload` | ✅ Done | #253 |
 | S3 | #3+#4 Settings persistence | `feat/settings-persistence` | 🔲 Pending | — |
 | S4 | #3+#4 continued (if needed) | `feat/settings-persistence` | 🔲 Pending | — |
-| S5 | #6 Tag sort/collapse | `feat/tag-sort-collapse` | 🔲 Pending | — |
+| S5 | #6 Tag sort/collapse | `feat/tag-sort-collapse` | ✅ Done | — |
 | S6 | #8+#9 Auto-resize textarea | `feat/auto-resize-textarea` | 🔲 Pending | — |
 | S7 | #11 Test effectiveness | `chore/test-effectiveness` | 🔲 Pending | — |
 | S8 | #7 Social feed own POKs | `feat/social-feed-own-poks` | 🔲 Pending | — |

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "learnimo",
     "slug": "learnimo",
-    "version": "1.0.20",
+    "version": "1.0.21",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",

--- a/mobile/src/components/feed/LearningCard.tsx
+++ b/mobile/src/components/feed/LearningCard.tsx
@@ -56,7 +56,7 @@ export function LearningCard({ pok, onPress }: Props) {
           <View style={{ flexDirection: 'row', gap: spacing.xs, flexWrap: 'wrap', justifyContent: 'flex-end', flex: 1, marginLeft: spacing.sm }}>
             {[...pok.tags].sort((a, b) => (b.pokCount ?? 0) - (a.pokCount ?? 0)).slice(0, 3).map((tag) => (
               <View
-                key={tag.id}
+                key={tag.tagId}
                 style={{
                   backgroundColor: colors.tagPillBg,
                   borderRadius: theme.radii.full,

--- a/mobile/src/components/feed/LearningCard.tsx
+++ b/mobile/src/components/feed/LearningCard.tsx
@@ -54,7 +54,7 @@ export function LearningCard({ pok, onPress }: Props) {
 
         {pok.tags.length > 0 && (
           <View style={{ flexDirection: 'row', gap: spacing.xs, flexWrap: 'wrap', justifyContent: 'flex-end', flex: 1, marginLeft: spacing.sm }}>
-            {pok.tags.slice(0, 3).map((tag) => (
+            {[...pok.tags].sort((a, b) => (b.pokCount ?? 0) - (a.pokCount ?? 0)).slice(0, 3).map((tag) => (
               <View
                 key={tag.id}
                 style={{

--- a/mobile/src/i18n/locales/en.ts
+++ b/mobile/src/i18n/locales/en.ts
@@ -123,6 +123,8 @@ export default {
       tagListLoadErrorTitle: 'Could not load tags',
       tagListLoadErrorMessage: 'Failed to load your tags. Please try again.',
       removeTagAccessibilityLabel: 'Remove tag %{tagName}',
+      showAllTags: 'Show all (%{count})',
+      showLessTags: 'Show less',
     },
     visibility: {
       private: 'Private',

--- a/mobile/src/i18n/locales/pt-BR.ts
+++ b/mobile/src/i18n/locales/pt-BR.ts
@@ -121,6 +121,8 @@ export default {
       tagListLoadErrorTitle: 'Não foi possível carregar etiquetas',
       tagListLoadErrorMessage: 'Falha ao carregar suas etiquetas. Tente novamente.',
       removeTagAccessibilityLabel: 'Remover etiqueta %{tagName}',
+      showAllTags: 'Mostrar todas (%{count})',
+      showLessTags: 'Mostrar menos',
     },
     visibility: {
       private: 'Privado',

--- a/mobile/src/lib/tagApi.ts
+++ b/mobile/src/lib/tagApi.ts
@@ -7,6 +7,7 @@ export interface Tag {
   displayName: string;
   color: string;
   createdAt: string;
+  pokCount: number;
 }
 
 export interface TagSuggestion {

--- a/mobile/src/screens/app/LearningDetailScreen.tsx
+++ b/mobile/src/screens/app/LearningDetailScreen.tsx
@@ -55,6 +55,7 @@ export function LearningDetailScreen() {
   const [tagModalVisible, setTagModalVisible] = useState(false);
   const [tagActionLoading, setTagActionLoading] = useState(false);
   const [tagQuery, setTagQuery] = useState('');
+  const [tagsExpanded, setTagsExpanded] = useState(false);
 
   const loadPok = useCallback(async () => {
     setLoading(true);
@@ -291,54 +292,78 @@ export function LearningDetailScreen() {
         {/* Tags section */}
         <View style={{ gap: theme.spacing.xs }}>
           <Text variant="label">{t('learnings.detail.tags')}</Text>
-          <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: theme.spacing.xs }}>
-            {pok.tags.map((tag) => (
-              <View
-                key={tag.tagId}
-                style={{
-                  flexDirection: 'row',
-                  alignItems: 'center',
-                  backgroundColor: theme.colors.tagPillBg,
-                  borderRadius: theme.radii.full,
-                  paddingLeft: theme.spacing.sm,
-                  paddingRight: theme.spacing.xs,
-                  paddingVertical: 2, /* canonical tag pill vertical padding (matches LearningCard) */
-                  gap: theme.spacing.xs,
-                }}
-              >
-                <Text variant="caption" color={theme.colors.tagPillText}>{tag.displayName}</Text>
-                <TouchableOpacity
-                  accessibilityRole="button"
-                  accessibilityLabel={t('learnings.detail.removeTagAccessibilityLabel', { tagName: tag.displayName })}
-                  onPress={() => handleRemoveTag(tag)}
-                  disabled={tagActionLoading}
-                  hitSlop={{ top: 8, right: 8, bottom: 8, left: 4 }}
-                >
-                  <Text variant="caption" color={theme.colors.tagPillText}>✕</Text>
-                </TouchableOpacity>
-              </View>
-            ))}
+          {(() => {
+            const TAG_COLLAPSE_LIMIT = 3;
+            const sortedTags = [...pok.tags].sort((a, b) => (b.pokCount ?? 0) - (a.pokCount ?? 0));
+            const visibleTags = tagsExpanded ? sortedTags : sortedTags.slice(0, TAG_COLLAPSE_LIMIT);
+            const hasOverflow = sortedTags.length > TAG_COLLAPSE_LIMIT;
+            return (
+              <>
+                <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: theme.spacing.xs }}>
+                  {visibleTags.map((tag) => (
+                    <View
+                      key={tag.tagId}
+                      style={{
+                        flexDirection: 'row',
+                        alignItems: 'center',
+                        backgroundColor: theme.colors.tagPillBg,
+                        borderRadius: theme.radii.full,
+                        paddingLeft: theme.spacing.sm,
+                        paddingRight: theme.spacing.xs,
+                        paddingVertical: 2, /* canonical tag pill vertical padding (matches LearningCard) */
+                        gap: theme.spacing.xs,
+                      }}
+                    >
+                      <Text variant="caption" color={theme.colors.tagPillText}>{tag.displayName}</Text>
+                      <TouchableOpacity
+                        accessibilityRole="button"
+                        accessibilityLabel={t('learnings.detail.removeTagAccessibilityLabel', { tagName: tag.displayName })}
+                        onPress={() => handleRemoveTag(tag)}
+                        disabled={tagActionLoading}
+                        hitSlop={{ top: 8, right: 8, bottom: 8, left: 4 }}
+                      >
+                        <Text variant="caption" color={theme.colors.tagPillText}>✕</Text>
+                      </TouchableOpacity>
+                    </View>
+                  ))}
 
-            {/* Add tag button */}
-            <TouchableOpacity
-              accessibilityRole="button"
-              onPress={openTagModal}
-              disabled={tagActionLoading}
-              style={{
-                flexDirection: 'row',
-                alignItems: 'center',
-                borderRadius: theme.radii.full,
-                paddingHorizontal: theme.spacing.md,
-                paddingVertical: theme.spacing.xs,
-                borderWidth: 1,
-                borderStyle: 'dashed',
-                borderColor: theme.colors.border,
-                gap: theme.spacing.xs,
-              }}
-            >
-              <Text variant="caption" color={theme.colors.textSecondary}>+ {t('learnings.detail.addTag')}</Text>
-            </TouchableOpacity>
-          </View>
+                  {/* Add tag button */}
+                  <TouchableOpacity
+                    accessibilityRole="button"
+                    onPress={openTagModal}
+                    disabled={tagActionLoading}
+                    style={{
+                      flexDirection: 'row',
+                      alignItems: 'center',
+                      borderRadius: theme.radii.full,
+                      paddingHorizontal: theme.spacing.md,
+                      paddingVertical: theme.spacing.xs,
+                      borderWidth: 1,
+                      borderStyle: 'dashed',
+                      borderColor: theme.colors.border,
+                      gap: theme.spacing.xs,
+                    }}
+                  >
+                    <Text variant="caption" color={theme.colors.textSecondary}>+ {t('learnings.detail.addTag')}</Text>
+                  </TouchableOpacity>
+                </View>
+
+                {/* Collapse / expand toggle */}
+                {hasOverflow && (
+                  <TouchableOpacity
+                    accessibilityRole="button"
+                    onPress={() => setTagsExpanded(prev => !prev)}
+                  >
+                    <Text variant="caption" color={theme.colors.primary}>
+                      {tagsExpanded
+                        ? t('learnings.detail.showLessTags')
+                        : t('learnings.detail.showAllTags', { count: String(sortedTags.length) })}
+                    </Text>
+                  </TouchableOpacity>
+                )}
+              </>
+            );
+          })()}
         </View>
 
         <View style={{ flexDirection: 'row', gap: theme.spacing.sm, marginTop: theme.spacing.md }}>

--- a/mobile/src/screens/app/LearningDetailScreen.tsx
+++ b/mobile/src/screens/app/LearningDetailScreen.tsx
@@ -32,6 +32,8 @@ import { VisibilityPicker, VisibilityBadge, getDisabledValues } from '@/componen
 
 type RouteProps = RouteProp<AppStackParamList, 'LearningDetail'>;
 
+const TAG_COLLAPSE_LIMIT = 3;
+
 export function LearningDetailScreen() {
   const { theme } = useTheme();
   const { t } = useI18n();
@@ -293,7 +295,6 @@ export function LearningDetailScreen() {
         <View style={{ gap: theme.spacing.xs }}>
           <Text variant="label">{t('learnings.detail.tags')}</Text>
           {(() => {
-            const TAG_COLLAPSE_LIMIT = 3;
             const sortedTags = [...pok.tags].sort((a, b) => (b.pokCount ?? 0) - (a.pokCount ?? 0));
             const visibleTags = tagsExpanded ? sortedTags : sortedTags.slice(0, TAG_COLLAPSE_LIMIT);
             const hasOverflow = sortedTags.length > TAG_COLLAPSE_LIMIT;

--- a/mobile/src/screens/app/__tests__/LearningDetailScreen.test.tsx
+++ b/mobile/src/screens/app/__tests__/LearningDetailScreen.test.tsx
@@ -23,6 +23,7 @@ interface TestState {
   tagModalVisible: boolean;
   tagActionLoading: boolean;
   tagQuery: string;
+  tagsExpanded: boolean;
 }
 
 let mockTestState: TestState = {
@@ -32,12 +33,13 @@ let mockTestState: TestState = {
   tagModalVisible: false,
   tagActionLoading: false,
   tagQuery: '',
+  tagsExpanded: false,
 };
 
-// useState call order in LearningDetailScreen (12 calls):
+// useState call order in LearningDetailScreen (13 calls):
 // 1=pok  2=loading  3=editing  4=error  5=serverError  6=editVisibility
 // 7=reLearningModalVisible  8=hasRelearned  9=allTags  10=tagModalVisible
-// 11=tagActionLoading  12=tagQuery
+// 11=tagActionLoading  12=tagQuery  13=tagsExpanded
 jest.mock('react', () => {
   const actual = jest.requireActual('react');
   return {
@@ -51,6 +53,7 @@ jest.mock('react', () => {
         case 10: return [mockTestState.tagModalVisible, jest.fn()];
         case 11: return [mockTestState.tagActionLoading, mockSetTagActionLoading];
         case 12: return [mockTestState.tagQuery, jest.fn()];
+        case 13: return [mockTestState.tagsExpanded, jest.fn()];
         default: return [init, jest.fn()];
       }
     },
@@ -201,6 +204,7 @@ const existingTag = {
   displayName: 'Existing',
   color: '#ccc',
   createdAt: '2026-01-01T00:00:00Z',
+  pokCount: 5,
 };
 
 const mockPokWithTag = {
@@ -221,6 +225,7 @@ const newTag = {
   displayName: 'New Tag',
   color: '#aaa',
   createdAt: '2026-01-01T00:00:00Z',
+  pokCount: 1,
 };
 
 // ---------------------------------------------------------------------------
@@ -262,6 +267,7 @@ describe('LearningDetailScreen — tag creation flow', () => {
       tagModalVisible: false,
       tagActionLoading: false,
       tagQuery: '',
+      tagsExpanded: false,
     };
     // Re-wire hooks after clearAllMocks
     const reactMock = require('react') as Record<string, unknown>;
@@ -441,6 +447,137 @@ describe('LearningDetailScreen — tag creation flow', () => {
 
       expect(mockTagAssign).toHaveBeenCalledWith('pok-1', availableTag.tagId);
       expect(mockSetPok).toHaveBeenCalled();
+    });
+  });
+
+  describe('tag sort and collapse', () => {
+    const makeTag = (tagId: string, displayName: string, pokCount: number) => ({
+      tagId,
+      id: tagId,
+      name: displayName.toLowerCase(),
+      displayName,
+      color: '#ccc',
+      createdAt: '2026-01-01T00:00:00Z',
+      pokCount,
+    });
+
+    it('renders only 3 tags when there are more than 3 and not expanded', () => {
+      mockTestState.pok = {
+        ...mockPokWithTag,
+        tags: [
+          makeTag('t1', 'Alpha', 1),
+          makeTag('t2', 'Beta', 10),
+          makeTag('t3', 'Gamma', 5),
+          makeTag('t4', 'Delta', 3),
+        ],
+      };
+      mockTestState.tagsExpanded = false;
+
+      const result = LearningDetailScreen({} as never);
+      // Find all Text nodes whose children are tag displayNames (they're inside caption Text elements)
+      const allTexts = findAllByType(result, 'Text');
+      const tagLabels = allTexts
+        .filter(el => ['Alpha', 'Beta', 'Gamma', 'Delta'].includes(el.props.children as string))
+        .map(el => el.props.children as string);
+      expect(tagLabels).toHaveLength(3);
+    });
+
+    it('shows tags sorted by pokCount descending', () => {
+      mockTestState.pok = {
+        ...mockPokWithTag,
+        tags: [
+          makeTag('t1', 'Alpha', 1),
+          makeTag('t2', 'Beta', 10),
+          makeTag('t3', 'Gamma', 5),
+        ],
+      };
+
+      const result = LearningDetailScreen({} as never);
+      const allTexts = findAllByType(result, 'Text');
+      const tagLabels = allTexts
+        .filter(el => ['Alpha', 'Beta', 'Gamma'].includes(el.props.children as string))
+        .map(el => el.props.children as string);
+      expect(tagLabels).toEqual(['Beta', 'Gamma', 'Alpha']);
+    });
+
+    it('renders expand toggle when there are more than 3 tags', () => {
+      mockTestState.pok = {
+        ...mockPokWithTag,
+        tags: [
+          makeTag('t1', 'Alpha', 1),
+          makeTag('t2', 'Beta', 10),
+          makeTag('t3', 'Gamma', 5),
+          makeTag('t4', 'Delta', 3),
+        ],
+      };
+      mockTestState.tagsExpanded = false;
+
+      const result = LearningDetailScreen({} as never);
+      const allTexts = findAllByType(result, 'Text');
+      const showAllText = allTexts.find(el =>
+        typeof el.props.children === 'string' &&
+        (el.props.children as string).includes('showAllTags')
+      );
+      expect(showAllText).toBeDefined();
+    });
+
+    it('shows "show less" toggle when expanded', () => {
+      mockTestState.pok = {
+        ...mockPokWithTag,
+        tags: [
+          makeTag('t1', 'Alpha', 1),
+          makeTag('t2', 'Beta', 10),
+          makeTag('t3', 'Gamma', 5),
+          makeTag('t4', 'Delta', 3),
+        ],
+      };
+      mockTestState.tagsExpanded = true;
+
+      const result = LearningDetailScreen({} as never);
+      const allTexts = findAllByType(result, 'Text');
+      const showLessText = allTexts.find(el =>
+        el.props.children === 'learnings.detail.showLessTags'
+      );
+      expect(showLessText).toBeDefined();
+    });
+
+    it('renders all tags when expanded', () => {
+      mockTestState.pok = {
+        ...mockPokWithTag,
+        tags: [
+          makeTag('t1', 'Alpha', 1),
+          makeTag('t2', 'Beta', 10),
+          makeTag('t3', 'Gamma', 5),
+          makeTag('t4', 'Delta', 3),
+        ],
+      };
+      mockTestState.tagsExpanded = true;
+
+      const result = LearningDetailScreen({} as never);
+      const allTexts = findAllByType(result, 'Text');
+      const tagLabels = allTexts
+        .filter(el => ['Alpha', 'Beta', 'Gamma', 'Delta'].includes(el.props.children as string))
+        .map(el => el.props.children as string);
+      expect(tagLabels).toHaveLength(4);
+    });
+
+    it('does not render expand toggle when 3 or fewer tags', () => {
+      mockTestState.pok = {
+        ...mockPokWithTag,
+        tags: [
+          makeTag('t1', 'Alpha', 1),
+          makeTag('t2', 'Beta', 10),
+        ],
+      };
+
+      const result = LearningDetailScreen({} as never);
+      const allTexts = findAllByType(result, 'Text');
+      const toggleText = allTexts.find(el =>
+        typeof el.props.children === 'string' &&
+        ((el.props.children as string).includes('showAllTags') ||
+         (el.props.children as string).includes('showLessTags'))
+      );
+      expect(toggleText).toBeUndefined();
     });
   });
 });

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -66,6 +66,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
       "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -1825,6 +1826,7 @@
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -1846,6 +1848,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -1855,12 +1858,14 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -2058,6 +2063,7 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
@@ -2071,6 +2077,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -2080,6 +2087,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
@@ -2410,7 +2418,7 @@
       "version": "1.58.2",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
       "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright": "1.58.2"
@@ -2992,7 +3000,7 @@
       "version": "0.5.19",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.19.tgz",
       "integrity": "sha512-QamiFeIK3txNjgUTNppE6MiG3p7TdninpZu0E0PbqVh1a9FNLT2FRhisaa4NcaX52XVhA5l7Pk58Ft7Sqi/2sA==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
@@ -3288,6 +3296,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -4096,12 +4105,14 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
       "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "normalize-path": "^3.0.0",
@@ -4115,6 +4126,7 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
       "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/argparse": {
@@ -4453,6 +4465,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
       "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4476,6 +4489,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -4582,6 +4596,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
       "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -4688,6 +4703,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
       "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "anymatch": "~3.1.2",
@@ -4712,6 +4728,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -4769,6 +4786,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
       "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -4856,6 +4874,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -5047,12 +5066,14 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/dlv": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/doctrine": {
@@ -5844,6 +5865,7 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
       "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -5860,6 +5882,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -5886,6 +5909,7 @@
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
       "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -5908,6 +5932,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -5988,6 +6013,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -6002,6 +6028,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -6132,6 +6159,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.3"
@@ -6268,6 +6296,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -6566,6 +6595,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "binary-extensions": "^2.0.0"
@@ -6618,6 +6648,7 @@
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
       "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.2"
@@ -6771,6 +6802,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -7032,6 +7064,7 @@
       "version": "1.21.7",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "bin/jiti.js"
@@ -7218,6 +7251,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
       "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -7230,6 +7264,7 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/locate-path": {
@@ -7658,6 +7693,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -8230,6 +8266,7 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
@@ -8282,6 +8319,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
       "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "any-promise": "^1.0.0",
@@ -8561,6 +8599,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -8570,6 +8609,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -8579,6 +8619,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
       "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -8851,6 +8892,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/pathe": {
@@ -8870,6 +8912,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -8882,6 +8925,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -8891,6 +8935,7 @@
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
       "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -8900,7 +8945,7 @@
       "version": "1.58.2",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
       "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "1.58.2"
@@ -8919,7 +8964,7 @@
       "version": "1.58.2",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
       "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
@@ -8932,6 +8977,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -8962,6 +9008,7 @@
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
       "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -8990,6 +9037,7 @@
       "version": "15.1.0",
       "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
       "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "postcss-value-parser": "^4.0.0",
@@ -9007,6 +9055,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
       "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -9032,6 +9081,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
       "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -9074,6 +9124,7 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
       "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -9099,6 +9150,7 @@
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
       "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -9112,6 +9164,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/prelude-ls": {
@@ -9195,6 +9248,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -9296,6 +9350,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
       "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pify": "^2.3.0"
@@ -9305,6 +9360,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "picomatch": "^2.2.1"
@@ -9465,6 +9521,7 @@
       "version": "1.22.11",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
       "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-core-module": "^2.16.1",
@@ -9505,6 +9562,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
       "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
@@ -9560,6 +9618,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -10128,6 +10187,7 @@
       "version": "3.35.1",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
       "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.2",
@@ -10163,6 +10223,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -10192,6 +10253,7 @@
       "version": "3.4.19",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
@@ -10229,6 +10291,7 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
       "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "any-promise": "^1.0.0"
@@ -10238,6 +10301,7 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
       "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "thenify": ">= 3.1.0 < 4"
@@ -10267,6 +10331,7 @@
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
       "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -10283,6 +10348,7 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -10300,6 +10366,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -10342,6 +10409,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -10413,6 +10481,7 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/tsconfig-paths": {
@@ -10529,7 +10598,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/web/src/lib/tagApi.ts
+++ b/web/src/lib/tagApi.ts
@@ -10,6 +10,7 @@ export interface Tag {
   displayName: string;
   color: string;
   createdAt: string;
+  pokCount: number;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Tags on the learning detail screen are now sorted by frequency (most-used first) and collapsed to top 3 with a "Show all (N)" / "Show less" toggle
- Feed cards (`LearningCard`) also sort tags by frequency before slicing to top 3 for visual consistency
- Closes closed-testing triage v1.0.19 item #6

## Changes

- feat(backend): add pokCount to tag responses
- feat(mobile): sort tags by frequency, collapse to top 3 with expand toggle
- feat(web): add pokCount to Tag interface
- docs: update phase-1 roadmap and triage plan for tag sort/collapse (S5 item #6)

## Implementation Notes

**Backend:** `PokTagRepository.countPoksByTagForUser()` GROUP BY query (no migration). `TagResponse` gains a `pokCount` field. All tag-fetching paths (`TagService`, `PokService`, `LearnerService`) populate it via a single count map per request.

**Mobile:** `LearningDetailScreen` sorts `pok.tags` by `pokCount` descending, slices to 3 when collapsed, and renders a `TouchableOpacity` toggle when `tags.length > 3`. i18n keys added to EN and PT-BR.

## Testing

- [x] Backend: 465 tests, JaCoCo 93.2% line coverage
- [x] Mobile: 410 tests (lint clean), 6 new tests covering sort order, collapse, expand toggle, show-less
- [x] Web: 450 tests + production build OK
- [x] Mobile version bumped to 1.0.21

## Documentation

- [x] `docs/ROADMAP.phase-1.md` — tag sort/collapse marked ✅ Done
- [x] `docs/plans/closed-testing-triage-v1.0.19.md` — S5 item #6 marked ✅ Done
- [x] `backend/CLAUDE.md` — new pitfall: `List.<Object[]>of(...)` type witness

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>