### PR TITLE
feat(auth): Sign in with Apple — backend + mobile

### DIFF
--- a/backend/src/main/java/com/lucasxf/ed/controller/AuthMobileController.java
+++ b/backend/src/main/java/com/lucasxf/ed/controller/AuthMobileController.java
@@ -11,13 +11,17 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.lucasxf.ed.dto.AppleLoginRequest;
+import com.lucasxf.ed.dto.AppleLoginResponse;
 import com.lucasxf.ed.dto.AuthResponse;
+import com.lucasxf.ed.dto.CompleteAppleSignupRequest;
 import com.lucasxf.ed.dto.CompleteGoogleSignupRequest;
 import com.lucasxf.ed.dto.GoogleLoginRequest;
 import com.lucasxf.ed.dto.GoogleLoginResponse;
 import com.lucasxf.ed.dto.LoginRequest;
 import com.lucasxf.ed.dto.RefreshRequest;
 import com.lucasxf.ed.dto.RegisterRequest;
+import com.lucasxf.ed.service.AppleLoginResult;
 import com.lucasxf.ed.service.AuthResult;
 import com.lucasxf.ed.service.AuthService;
 import com.lucasxf.ed.service.GoogleLoginResult;
@@ -125,5 +129,35 @@ public class AuthMobileController {
             result.handle(), result.userId(), result.email(),
             result.accessToken(), result.refreshToken(),
             result.defaultPokVisibility(), result.profileVisibility()));
+    }
+
+    @PostMapping("/apple")
+    @Operation(summary = "Log in with Apple (mobile)",
+        description = "Verifies an Apple identity token. Returns tokens in the JSON body for existing "
+            + "users, or a temp token and email for new users who need to choose a handle.")
+    @ApiResponse(responseCode = "200", description = "Token verified — see requiresHandle field")
+    @ApiResponse(responseCode = "401", description = "Invalid or expired Apple identity token")
+    @ApiResponse(responseCode = "409", description = "Email already registered with another provider")
+    public ResponseEntity<AppleLoginResponse> appleLogin(@Valid @RequestBody AppleLoginRequest request) {
+        AppleLoginResult result = authService.appleLogin(request.identityToken());
+        return switch (result) {
+            case AppleLoginResult.ExistingUser eu -> ResponseEntity.ok(AppleLoginResponse.existingUser(eu.authResult()));
+            case AppleLoginResult.NewUser nu -> ResponseEntity.ok(AppleLoginResponse.newUser(nu.tempToken(), nu.email()));
+        };
+    }
+
+    @PostMapping("/apple/complete")
+    @Operation(summary = "Complete Sign in with Apple registration (mobile)",
+        description = "Creates a new user account for an Apple OAuth user with their chosen handle. "
+            + "Returns tokens in the JSON body — no cookies set.")
+    @ApiResponse(responseCode = "200", description = "Registration complete, tokens issued")
+    @ApiResponse(responseCode = "400", description = "Invalid handle format")
+    @ApiResponse(responseCode = "401", description = "Temp token expired")
+    @ApiResponse(responseCode = "409", description = "Handle already taken")
+    public ResponseEntity<AppleLoginResponse> completeAppleSignup(
+        @Valid @RequestBody CompleteAppleSignupRequest request) {
+        AuthResult tokens = authService.completeAppleSignup(
+            request.tempToken(), request.handle(), request.displayName());
+        return ResponseEntity.ok(AppleLoginResponse.existingUser(tokens));
     }
 }

--- a/backend/src/main/java/com/lucasxf/ed/domain/User.java
+++ b/backend/src/main/java/com/lucasxf/ed/domain/User.java
@@ -56,6 +56,9 @@ public class User {
     @Column(name = "profile_visibility", nullable = false, length = 20)
     private ProfileVisibility profileVisibility = ProfileVisibility.PRIVATE;
 
+    @Column(name = "apple_sub", length = 255)
+    private String appleSub;
+
     @Column(name = "avatar_url", length = 500)
     private String avatarUrl;
 
@@ -150,6 +153,14 @@ public class User {
 
     public void setProfileVisibility(ProfileVisibility profileVisibility) {
         this.profileVisibility = profileVisibility;
+    }
+
+    public String getAppleSub() {
+        return appleSub;
+    }
+
+    public void setAppleSub(String appleSub) {
+        this.appleSub = appleSub;
     }
 
     public String getAvatarUrl() {

--- a/backend/src/main/java/com/lucasxf/ed/dto/AppleLoginRequest.java
+++ b/backend/src/main/java/com/lucasxf/ed/dto/AppleLoginRequest.java
@@ -1,0 +1,19 @@
+package com.lucasxf.ed.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * Request DTO for Sign in with Apple.
+ *
+ * @author Lucas Xavier Ferreira
+ * @since 2026-04-18
+ */
+@Schema(description = "Sign in with Apple request")
+public record AppleLoginRequest(
+
+    @Schema(description = "Apple identity token from Sign in with Apple")
+    @NotBlank(message = "Apple identity token is required")
+    String identityToken
+) {
+}

--- a/backend/src/main/java/com/lucasxf/ed/dto/AppleLoginResponse.java
+++ b/backend/src/main/java/com/lucasxf/ed/dto/AppleLoginResponse.java
@@ -1,0 +1,67 @@
+package com.lucasxf.ed.dto;
+
+import java.util.UUID;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import com.lucasxf.ed.service.AuthResult;
+
+/**
+ * Response DTO for Sign in with Apple.
+ *
+ * <p>If the user exists, tokens are delivered via {@code httpOnly} cookies (web) and in
+ * the JSON body ({@code accessToken}, {@code refreshToken}) for mobile clients. If the
+ * user is new, returns a temp token and email for handle selection ({@code requiresHandle=true}).
+ *
+ * @author Lucas Xavier Ferreira
+ * @since 2026-04-18
+ */
+@Schema(description = "Sign in with Apple response")
+public record AppleLoginResponse(
+
+    @Schema(description = "Whether the user needs to choose a handle (first-time Apple user)")
+    boolean requiresHandle,
+
+    @Schema(description = "Temporary token for completing registration (only when requiresHandle=true)")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    String tempToken,
+
+    @Schema(description = "User email address (present for new users to pre-fill the form; only when requiresHandle=true)")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    String email,
+
+    @Schema(description = "User handle (only when requiresHandle=false)")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    String handle,
+
+    @Schema(description = "User ID (only when requiresHandle=false)")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    UUID userId,
+
+    @Schema(description = "JWT access token — mobile clients only; web clients use the access_token cookie")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    String accessToken,
+
+    @Schema(description = "Opaque refresh token — mobile clients only; web clients use the refresh_token cookie")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    String refreshToken) {
+
+    /**
+     * Creates a response for an existing Apple user (returning user).
+     * Tokens are delivered via cookies (web) and JSON body (mobile).
+     */
+    public static AppleLoginResponse existingUser(AuthResult authResult) {
+        return new AppleLoginResponse(
+            false, null, null,
+            authResult.handle(), authResult.userId(),
+            authResult.accessToken(), authResult.refreshToken());
+    }
+
+    /**
+     * Creates a response for a new Apple user who needs to choose a handle.
+     */
+    public static AppleLoginResponse newUser(String tempToken, String email) {
+        return new AppleLoginResponse(true, tempToken, email, null, null, null, null);
+    }
+}

--- a/backend/src/main/java/com/lucasxf/ed/dto/CompleteAppleSignupRequest.java
+++ b/backend/src/main/java/com/lucasxf/ed/dto/CompleteAppleSignupRequest.java
@@ -1,0 +1,34 @@
+package com.lucasxf.ed.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+/**
+ * Request DTO for completing Sign in with Apple registration with handle selection.
+ *
+ * @author Lucas Xavier Ferreira
+ * @since 2026-04-18
+ */
+@Schema(description = "Complete Sign in with Apple signup request")
+public record CompleteAppleSignupRequest(
+
+    @Schema(description = "Temporary token from the initial Apple login step")
+    @NotBlank(message = "Temp token is required")
+    String tempToken,
+
+    @Schema(description = "Unique handle (3-30 chars, lowercase alphanumeric and hyphens)",
+        example = "bobsmith")
+    @NotBlank(message = "Handle is required")
+    @Pattern(regexp = "^[a-z0-9](?:[a-z0-9]|-(?=[a-z0-9])){1,28}[a-z0-9]$",
+        message = "Handle must be 3-30 characters, lowercase alphanumeric and hyphens, "
+            + "no consecutive hyphens, must start and end with alphanumeric")
+    String handle,
+
+    @Schema(description = "Display name", example = "Bob Smith")
+    @NotBlank(message = "Display name is required")
+    @Size(max = 100, message = "Display name must not exceed 100 characters")
+    String displayName
+) {
+}

--- a/backend/src/main/java/com/lucasxf/ed/repository/UserRepository.java
+++ b/backend/src/main/java/com/lucasxf/ed/repository/UserRepository.java
@@ -27,6 +27,10 @@ public interface UserRepository extends JpaRepository<User, UUID> {
 
     boolean existsByHandle(String handle);
 
+    Optional<User> findByAppleSub(String appleSub);
+
+    boolean existsByAppleSub(String appleSub);
+
     /**
      * Searches for learners with {@code PUBLIC} profile visibility whose handle or display name
      * contains the given query string (case-insensitive, substring match).

--- a/backend/src/main/java/com/lucasxf/ed/service/AppleIdentityTokenVerifier.java
+++ b/backend/src/main/java/com/lucasxf/ed/service/AppleIdentityTokenVerifier.java
@@ -1,0 +1,131 @@
+package com.lucasxf.ed.service;
+
+import java.nio.charset.StandardCharsets;
+import java.security.interfaces.RSAPublicKey;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.stereotype.Service;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.lucasxf.ed.exception.AuthenticationException;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import lombok.extern.slf4j.Slf4j;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Verifies Apple identity tokens (RS256 JWTs) issued by Sign in with Apple.
+ *
+ * <p>Uses {@link AppleJwkCache} to retrieve Apple's public keys and JJWT 0.13 to
+ * validate signature, expiry, issuer, and audience claims.
+ *
+ * @author Lucas Xavier Ferreira
+ * @since 2026-04-18
+ */
+@Slf4j
+@Service
+public class AppleIdentityTokenVerifier {
+
+    private static final String APPLE_ISSUER = "https://appleid.apple.com";
+    private static final String APPLE_AUDIENCE = "net.learnimo.app";
+    private static final String EXPECTED_ALG = "RS256";
+
+    private final AppleJwkCache appleJwkCache;
+    private final ObjectMapper objectMapper;
+
+    public AppleIdentityTokenVerifier(AppleJwkCache appleJwkCache, ObjectMapper objectMapper) {
+        this.appleJwkCache = requireNonNull(appleJwkCache, "appleJwkCache must not be null");
+        this.objectMapper = requireNonNull(objectMapper, "objectMapper must not be null");
+    }
+
+    /**
+     * Verifies an Apple identity token and extracts the user's stable ID and email.
+     *
+     * @param identityToken the raw JWT from Sign in with Apple
+     * @return verified Apple user information
+     * @throws AuthenticationException if the token is invalid, expired, tampered, or
+     *                                 fails issuer/audience/algorithm checks
+     */
+    public AppleUserInfo verify(String identityToken) {
+        requireNonNull(identityToken, "identityToken must not be null");
+
+        try {
+            // Step 1 — parse the JWT header
+            String[] parts = identityToken.split("\\.", -1);
+            if (parts.length != 3) {
+                throw new AuthenticationException("Invalid Apple identity token format");
+            }
+            String headerJson = new String(
+                Base64.getUrlDecoder().decode(parts[0]), StandardCharsets.UTF_8);
+            Map<String, String> header = objectMapper.readValue(
+                headerJson, new TypeReference<>() { });
+
+            // Step 2 — assert algorithm
+            String alg = header.get("alg");
+            if (!EXPECTED_ALG.equals(alg)) {
+                throw new AuthenticationException(
+                    "Unexpected algorithm in Apple identity token: " + alg);
+            }
+
+            // Step 3 — look up the public key by kid
+            String kid = header.get("kid");
+            Map<String, RSAPublicKey> keys = appleJwkCache.getKeys();
+            RSAPublicKey publicKey = keys.get(kid);
+            if (publicKey == null) {
+                log.warn("Unknown kid in Apple identity token: {}", kid);
+                throw new AuthenticationException(
+                    "Unknown key ID in Apple identity token: " + kid);
+            }
+
+            // Step 4 — verify signature + expiry with JJWT
+            Claims claims = Jwts.parser()
+                .verifyWith(publicKey)
+                .build()
+                .parseSignedClaims(identityToken)
+                .getPayload();
+
+            // Step 5 — assert issuer
+            String iss = claims.getIssuer();
+            if (!APPLE_ISSUER.equals(iss)) {
+                throw new AuthenticationException(
+                    "Invalid issuer in Apple identity token: " + iss);
+            }
+
+            // Step 6 — assert audience contains the bundle ID
+            List<String> audience = claims.getAudience().stream().toList();
+            if (!audience.contains(APPLE_AUDIENCE)) {
+                throw new AuthenticationException(
+                    "Invalid audience in Apple identity token: " + audience);
+            }
+
+            // Step 7 — extract sub and email
+            String sub = claims.getSubject();
+            String email = claims.get("email", String.class);
+
+            log.info("Apple identity token verified for sub={}", sub);
+            return new AppleUserInfo(sub, email);
+
+        } catch (AuthenticationException ex) {
+            throw ex;
+        } catch (JwtException ex) {
+            log.warn("Apple identity token JWT validation failed: {}", ex.getMessage());
+            throw new AuthenticationException("Apple identity token validation failed", ex);
+        } catch (Exception ex) {
+            log.warn("Failed to parse Apple identity token: {}", ex.getMessage());
+            throw new AuthenticationException("Failed to process Apple identity token", ex);
+        }
+    }
+
+    /**
+     * Verified Apple user information extracted from an identity token.
+     *
+     * @param sub   stable Apple user ID (never changes for a given user + app pair)
+     * @param email user's email (may be a private relay address or null if not shared)
+     */
+    public record AppleUserInfo(String sub, String email) { }
+}

--- a/backend/src/main/java/com/lucasxf/ed/service/AppleJwkCache.java
+++ b/backend/src/main/java/com/lucasxf/ed/service/AppleJwkCache.java
@@ -1,0 +1,119 @@
+package com.lucasxf.ed.service;
+
+import java.math.BigInteger;
+import java.net.URI;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.interfaces.RSAPublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.RSAPublicKeySpec;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.extern.slf4j.Slf4j;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Cache for Apple's public JWK set used to verify identity token signatures.
+ *
+ * <p>Fetches {@code https://appleid.apple.com/auth/keys} on first use and every 15 minutes.
+ * The cache is refreshed lazily (on cache miss), not on a background schedule.
+ *
+ * @author Lucas Xavier Ferreira
+ * @since 2026-04-18
+ */
+@Slf4j
+@Component
+public class AppleJwkCache {
+
+    private static final String APPLE_KEYS_URL = "https://appleid.apple.com/auth/keys";
+    private static final Duration TTL = Duration.ofMinutes(15);
+    private static final int TIMEOUT_MS = 3_000;
+
+    private final RestClient restClient;
+
+    private volatile Map<String, RSAPublicKey> cachedKeys;
+    private volatile Instant cacheExpiry = Instant.EPOCH;
+
+    public AppleJwkCache(RestClient.Builder restClientBuilder) {
+        requireNonNull(restClientBuilder, "restClientBuilder must not be null");
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(TIMEOUT_MS);
+        factory.setReadTimeout(TIMEOUT_MS);
+        this.restClient = restClientBuilder
+            .requestFactory(factory)
+            .baseUrl(APPLE_KEYS_URL)
+            .build();
+    }
+
+    /**
+     * Returns the cached Apple public keys, refreshing from Apple's JWKS endpoint if the
+     * cache has expired (TTL = 15 minutes).
+     *
+     * @return map of {@code kid} → {@link RSAPublicKey}
+     */
+    public Map<String, RSAPublicKey> getKeys() {
+        if (isCacheValid()) {
+            return cachedKeys;
+        }
+        return refreshCache();
+    }
+
+    private boolean isCacheValid() {
+        return cachedKeys != null && Instant.now().isBefore(cacheExpiry);
+    }
+
+    private synchronized Map<String, RSAPublicKey> refreshCache() {
+        // Double-checked locking: re-test inside the synchronized block
+        if (isCacheValid()) {
+            return cachedKeys;
+        }
+        log.info("Refreshing Apple JWK cache from {}", APPLE_KEYS_URL);
+        AppleKeysResponse response = restClient.get()
+            .uri(URI.create(APPLE_KEYS_URL))
+            .retrieve()
+            .body(AppleKeysResponse.class);
+
+        requireNonNull(response, "Apple JWKS response was null");
+        requireNonNull(response.keys(), "Apple JWKS response contained no keys");
+
+        Map<String, RSAPublicKey> keys = response.keys().stream()
+            .filter(k -> "RSA".equals(k.kty()) && "RS256".equals(k.alg()))
+            .collect(Collectors.toMap(JwkEntry::kid, AppleJwkCache::toRsaPublicKey));
+
+        cachedKeys = keys;
+        cacheExpiry = Instant.now().plus(TTL);
+        log.info("Apple JWK cache refreshed: {} keys loaded, expires at {}", keys.size(), cacheExpiry);
+        return keys;
+    }
+
+    private static RSAPublicKey toRsaPublicKey(JwkEntry entry) {
+        try {
+            Base64.Decoder decoder = Base64.getUrlDecoder();
+            BigInteger modulus = new BigInteger(1, decoder.decode(entry.n()));
+            BigInteger exponent = new BigInteger(1, decoder.decode(entry.e()));
+            RSAPublicKeySpec spec = new RSAPublicKeySpec(modulus, exponent);
+            return (RSAPublicKey) KeyFactory.getInstance("RSA").generatePublic(spec);
+        } catch (NoSuchAlgorithmException | InvalidKeySpecException ex) {
+            throw new IllegalStateException("Failed to build RSAPublicKey for kid=" + entry.kid(), ex);
+        }
+    }
+
+    // ── Internal response records ────────────────────────────────────────────
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    record AppleKeysResponse(List<JwkEntry> keys) { }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    record JwkEntry(String kid, String kty, String alg, String n, String e) { }
+}

--- a/backend/src/main/java/com/lucasxf/ed/service/AppleLoginResult.java
+++ b/backend/src/main/java/com/lucasxf/ed/service/AppleLoginResult.java
@@ -1,0 +1,32 @@
+package com.lucasxf.ed.service;
+
+/**
+ * Result of a Sign in with Apple login attempt returned by {@link AuthService#appleLogin(String)}.
+ *
+ * <p>Uses a sealed interface to model the two distinct outcomes:
+ * <ul>
+ *   <li>{@link ExistingUser} — the Apple sub (or email) matched an existing Apple account; an
+ *       {@link AuthResult} with tokens is ready to be delivered via cookies.</li>
+ *   <li>{@link NewUser} — first-time Apple sign-in; a short-lived temp token and email are
+ *       returned for the handle-selection flow.</li>
+ * </ul>
+ *
+ * @author Lucas Xavier Ferreira
+ * @since 2026-04-18
+ */
+public sealed interface AppleLoginResult {
+
+    /**
+     * The Apple sub matched an existing Apple account.
+     * The controller must set auth cookies from {@code authResult} and return
+     * the user identity in the response body.
+     */
+    record ExistingUser(AuthResult authResult) implements AppleLoginResult {}
+
+    /**
+     * First-time Apple sign-in. The user must choose a handle.
+     * The temp token is short-lived and must be sent to {@code /auth/mobile/apple/complete}.
+     * The email may be null if the user chose to hide their real email from Apple.
+     */
+    record NewUser(String tempToken, String email) implements AppleLoginResult {}
+}

--- a/backend/src/main/java/com/lucasxf/ed/service/AuthService.java
+++ b/backend/src/main/java/com/lucasxf/ed/service/AuthService.java
@@ -16,6 +16,7 @@ import com.lucasxf.ed.exception.InvalidTokenException;
 import com.lucasxf.ed.exception.ResourceConflictException;
 import com.lucasxf.ed.repository.RefreshTokenRepository;
 import com.lucasxf.ed.repository.UserRepository;
+import com.lucasxf.ed.service.AppleIdentityTokenVerifier.AppleUserInfo;
 import com.lucasxf.ed.service.GoogleTokenVerifierService.GoogleUserInfo;
 import lombok.extern.slf4j.Slf4j;
 
@@ -39,17 +40,20 @@ public class AuthService {
     private final JwtService jwtService;
     private final PasswordEncoder passwordEncoder;
     private final GoogleTokenVerifierService googleTokenVerifier;
+    private final AppleIdentityTokenVerifier appleIdentityTokenVerifier;
 
     public AuthService(UserRepository userRepository,
                        RefreshTokenRepository refreshTokenRepository,
                        JwtService jwtService,
                        PasswordEncoder passwordEncoder,
-                       GoogleTokenVerifierService googleTokenVerifier) {
+                       GoogleTokenVerifierService googleTokenVerifier,
+                       AppleIdentityTokenVerifier appleIdentityTokenVerifier) {
         this.userRepository = requireNonNull(userRepository);
         this.refreshTokenRepository = requireNonNull(refreshTokenRepository);
         this.jwtService = requireNonNull(jwtService);
         this.passwordEncoder = requireNonNull(passwordEncoder);
         this.googleTokenVerifier = requireNonNull(googleTokenVerifier);
+        this.appleIdentityTokenVerifier = requireNonNull(appleIdentityTokenVerifier);
     }
 
     /**
@@ -189,6 +193,72 @@ public class AuthService {
         userRepository.save(user);
 
         log.info("Google OAuth user created: handle={}, email={}", handle, email);
+        return issueTokens(user);
+    }
+
+    /**
+     * Authenticates a user with an Apple identity token.
+     *
+     * <p>Looks up the user first by Apple sub (stable ID), then by email as a fallback
+     * for accounts that existed before Apple sign-in was added.
+     *
+     * <p>If the user exists with {@code auth_provider=apple}, issues JWT tokens.
+     * If the user is new, returns a temp token for handle selection.
+     * If the email belongs to a non-Apple account (local or google), returns 409 Conflict.
+     *
+     * @throws ResourceConflictException if the email is already registered with a different provider
+     */
+    @Transactional
+    public AppleLoginResult appleLogin(String identityToken) {
+        AppleUserInfo userInfo = appleIdentityTokenVerifier.verify(identityToken);
+        String sub = userInfo.sub();
+        String rawEmail = userInfo.email();
+        String normalizedEmail = rawEmail != null ? rawEmail.toLowerCase(Locale.ROOT) : null;
+
+        User user = userRepository.findByAppleSub(sub)
+            .orElseGet(() -> normalizedEmail != null
+                ? userRepository.findByEmail(normalizedEmail).orElse(null)
+                : null);
+
+        if (user != null) {
+            if (!"apple".equals(user.getAuthProvider())) {
+                log.warn("Apple OAuth email conflict with {} account: email={}", user.getAuthProvider(),
+                    normalizedEmail);
+                throw new ResourceConflictException(
+                    "This email is already registered with a different sign-in method. "
+                        + "Please sign in using your original method.");
+            }
+            log.info("Apple OAuth login: handle={}", user.getHandle());
+            return new AppleLoginResult.ExistingUser(issueTokens(user));
+        }
+
+        log.info("Apple OAuth new user: sub={}", sub);
+        String tempToken = jwtService.generateAppleTempToken(sub, normalizedEmail);
+        return new AppleLoginResult.NewUser(tempToken, normalizedEmail);
+    }
+
+    /**
+     * Completes registration for a new Sign in with Apple user by creating their account.
+     *
+     * @throws InvalidTokenException if the temp token is invalid or expired
+     * @throws ResourceConflictException if the handle is already taken
+     */
+    @Transactional
+    public AuthResult completeAppleSignup(String tempToken, String handle, String displayName) {
+        Claims claims = jwtService.parseAppleTempToken(tempToken);
+
+        if (userRepository.existsByHandle(handle)) {
+            throw new ResourceConflictException("Handle already taken");
+        }
+
+        String email = claims.get("email", String.class);
+        String appleSub = claims.get("appleSub", String.class);
+        var user = new User(email, null, displayName, handle);
+        user.setAuthProvider("apple");
+        user.setAppleSub(appleSub);
+        userRepository.save(user);
+
+        log.info("Apple OAuth user created: handle={}, sub={}", handle, appleSub);
         return issueTokens(user);
     }
 

--- a/backend/src/main/java/com/lucasxf/ed/service/JwtService.java
+++ b/backend/src/main/java/com/lucasxf/ed/service/JwtService.java
@@ -37,6 +37,7 @@ import static java.util.Objects.requireNonNull;
 public class JwtService {
 
     private static final String GOOGLE_SIGNUP_TOKEN_TYPE = "google_signup";
+    private static final String APPLE_SIGNUP_TOKEN_TYPE = "apple_signup";
     private static final String INVALID_TEMP_TOKEN_MESSAGE = "Invalid or expired temp token";
 
     private final SecretKey signingKey;
@@ -148,6 +149,45 @@ public class JwtService {
             Claims claims = parseClaims(token);
             String type = claims.get("type", String.class);
             if (!GOOGLE_SIGNUP_TOKEN_TYPE.equals(type)) {
+                throw new InvalidTokenException(INVALID_TEMP_TOKEN_MESSAGE);
+            }
+            return claims;
+        } catch (JwtException e) {
+            throw new InvalidTokenException(INVALID_TEMP_TOKEN_MESSAGE, e);
+        }
+    }
+
+    /**
+     * Generates a short-lived temp token for two-step Sign in with Apple signup.
+     * Contains Apple user claims and a {@code type=apple_signup} marker.
+     * Expires after 5 minutes.
+     *
+     * @param appleSub the stable Apple user ID (subject)
+     * @param email    the user's email (may be null if Apple private relay was declined)
+     */
+    public String generateAppleTempToken(String appleSub, String email) {
+        Instant now = Instant.now();
+        return Jwts.builder()
+            .claim("type", APPLE_SIGNUP_TOKEN_TYPE)
+            .claim("appleSub", appleSub)
+            .claim("email", email)
+            .issuedAt(Date.from(now))
+            .expiration(Date.from(now.plus(Duration.ofMinutes(5))))
+            .signWith(signingKey)
+            .compact();
+    }
+
+    /**
+     * Parses and validates a temp token issued for Sign in with Apple signup.
+     *
+     * @return the token claims containing appleSub and email
+     * @throws InvalidTokenException if the token is invalid, expired, or not an apple temp token
+     */
+    public Claims parseAppleTempToken(String token) {
+        try {
+            Claims claims = parseClaims(token);
+            String type = claims.get("type", String.class);
+            if (!APPLE_SIGNUP_TOKEN_TYPE.equals(type)) {
                 throw new InvalidTokenException(INVALID_TEMP_TOKEN_MESSAGE);
             }
             return claims;

--- a/backend/src/main/resources/db/migration/V23__add_apple_sub_to_users.sql
+++ b/backend/src/main/resources/db/migration/V23__add_apple_sub_to_users.sql
@@ -1,0 +1,6 @@
+ALTER TABLE users
+  ADD COLUMN apple_sub VARCHAR(255) NULL;
+
+CREATE UNIQUE INDEX users_apple_sub_unique
+  ON users (apple_sub)
+  WHERE apple_sub IS NOT NULL;

--- a/backend/src/test/java/com/lucasxf/ed/controller/AuthMobileControllerAppleTest.java
+++ b/backend/src/test/java/com/lucasxf/ed/controller/AuthMobileControllerAppleTest.java
@@ -1,0 +1,219 @@
+package com.lucasxf.ed.controller;
+
+import java.util.UUID;
+
+import com.lucasxf.ed.config.AuthProperties;
+import com.lucasxf.ed.config.CorsProperties;
+import com.lucasxf.ed.exception.AuthenticationException;
+import com.lucasxf.ed.exception.ResourceConflictException;
+import com.lucasxf.ed.security.CookieHelper;
+import com.lucasxf.ed.security.SecurityConfig;
+import com.lucasxf.ed.service.AppleLoginResult;
+import com.lucasxf.ed.service.AuthResult;
+import com.lucasxf.ed.service.AuthService;
+import com.lucasxf.ed.service.JwtService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * MockMvc tests for Sign in with Apple endpoints in {@link AuthMobileController}.
+ *
+ * @author Lucas Xavier Ferreira
+ * @since 2026-04-18
+ */
+@WebMvcTest(AuthMobileController.class)
+@Import({SecurityConfig.class, CookieHelper.class})
+@EnableConfigurationProperties({CorsProperties.class, AuthProperties.class})
+@DisplayName("AuthMobileController — Sign in with Apple")
+class AuthMobileControllerAppleTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private AuthService authService;
+
+    @MockitoBean
+    private JwtService jwtService;
+
+    private static final UUID USER_ID = UUID.randomUUID();
+    private static final String EMAIL = "apple@privaterelay.appleid.com";
+    private static final String HANDLE = "appleuser";
+    private static final AuthResult AUTH_RESULT = new AuthResult(
+        "access-token", "refresh-token", HANDLE, USER_ID, EMAIL,
+        com.lucasxf.ed.domain.Pok.Visibility.PRIVATE, com.lucasxf.ed.domain.User.ProfileVisibility.PRIVATE
+    );
+
+    @Nested
+    @DisplayName("POST /api/v1/auth/mobile/apple")
+    class AppleLogin {
+
+        @Test
+        @DisplayName("should return 200 with tokens for existing Apple user")
+        void appleLogin_existingUser() throws Exception {
+            when(authService.appleLogin("valid-identity-token"))
+                .thenReturn(new AppleLoginResult.ExistingUser(AUTH_RESULT));
+
+            mockMvc.perform(post("/api/v1/auth/mobile/apple")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""
+                        { "identityToken": "valid-identity-token" }
+                        """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.requiresHandle").value(false))
+                .andExpect(jsonPath("$.accessToken").value("access-token"))
+                .andExpect(jsonPath("$.refreshToken").value("refresh-token"));
+        }
+
+        @Test
+        @DisplayName("should return 200 with temp token and email for new Apple user")
+        void appleLogin_newUser() throws Exception {
+            when(authService.appleLogin("valid-identity-token"))
+                .thenReturn(new AppleLoginResult.NewUser("temp-token-123", EMAIL));
+
+            mockMvc.perform(post("/api/v1/auth/mobile/apple")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""
+                        { "identityToken": "valid-identity-token" }
+                        """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.requiresHandle").value(true))
+                .andExpect(jsonPath("$.tempToken").value("temp-token-123"))
+                .andExpect(jsonPath("$.email").value(EMAIL));
+        }
+
+        @Test
+        @DisplayName("should return 401 for invalid Apple identity token")
+        void appleLogin_invalidToken() throws Exception {
+            when(authService.appleLogin("bad-token"))
+                .thenThrow(new AuthenticationException("Apple identity token validation failed"));
+
+            mockMvc.perform(post("/api/v1/auth/mobile/apple")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""
+                        { "identityToken": "bad-token" }
+                        """))
+                .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @DisplayName("should return 409 when Apple email conflicts with an existing account")
+        void appleLogin_emailConflict() throws Exception {
+            when(authService.appleLogin("valid-identity-token"))
+                .thenThrow(new ResourceConflictException(
+                    "This email is already registered with another provider"));
+
+            mockMvc.perform(post("/api/v1/auth/mobile/apple")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""
+                        { "identityToken": "valid-identity-token" }
+                        """))
+                .andExpect(status().isConflict());
+        }
+
+        @Test
+        @DisplayName("should return 400 for missing identityToken")
+        void appleLogin_missingToken() throws Exception {
+            mockMvc.perform(post("/api/v1/auth/mobile/apple")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("{}"))
+                .andExpect(status().isBadRequest());
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /api/v1/auth/mobile/apple/complete")
+    class CompleteAppleSignup {
+
+        @Test
+        @DisplayName("should return 200 with tokens on successful Apple signup completion")
+        void complete_success() throws Exception {
+            AuthResult result = new AuthResult(
+                "access-token", "refresh-token", "bobsmith", USER_ID, "bob@example.com",
+                com.lucasxf.ed.domain.Pok.Visibility.PRIVATE, com.lucasxf.ed.domain.User.ProfileVisibility.PRIVATE
+            );
+            when(authService.completeAppleSignup("temp-token", "bobsmith", "Bob Smith"))
+                .thenReturn(result);
+
+            mockMvc.perform(post("/api/v1/auth/mobile/apple/complete")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""
+                        {
+                            "tempToken": "temp-token",
+                            "handle": "bobsmith",
+                            "displayName": "Bob Smith"
+                        }
+                        """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.requiresHandle").value(false))
+                .andExpect(jsonPath("$.handle").value("bobsmith"))
+                .andExpect(jsonPath("$.accessToken").value("access-token"))
+                .andExpect(jsonPath("$.refreshToken").value("refresh-token"));
+        }
+
+        @Test
+        @DisplayName("should return 409 when handle is already taken")
+        void complete_handleTaken() throws Exception {
+            when(authService.completeAppleSignup(anyString(), anyString(), anyString()))
+                .thenThrow(new ResourceConflictException("Handle already taken"));
+
+            mockMvc.perform(post("/api/v1/auth/mobile/apple/complete")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""
+                        {
+                            "tempToken": "temp-token",
+                            "handle": "taken",
+                            "displayName": "Name"
+                        }
+                        """))
+                .andExpect(status().isConflict());
+        }
+
+        @Test
+        @DisplayName("should return 401 when temp token is expired")
+        void complete_expiredToken() throws Exception {
+            when(authService.completeAppleSignup(anyString(), anyString(), anyString()))
+                .thenThrow(new AuthenticationException("Session expired. Please try again."));
+
+            mockMvc.perform(post("/api/v1/auth/mobile/apple/complete")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""
+                        {
+                            "tempToken": "expired-token",
+                            "handle": "handle",
+                            "displayName": "Name"
+                        }
+                        """))
+                .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @DisplayName("should return 400 for invalid handle format")
+        void complete_invalidHandle() throws Exception {
+            mockMvc.perform(post("/api/v1/auth/mobile/apple/complete")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""
+                        {
+                            "tempToken": "temp-token",
+                            "handle": "-invalid",
+                            "displayName": "Name"
+                        }
+                        """))
+                .andExpect(status().isBadRequest());
+        }
+    }
+}

--- a/backend/src/test/java/com/lucasxf/ed/integration/AuthIntegrationTest.java
+++ b/backend/src/test/java/com/lucasxf/ed/integration/AuthIntegrationTest.java
@@ -2,6 +2,8 @@ package com.lucasxf.ed.integration;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.lucasxf.ed.repository.UserRepository;
+import com.lucasxf.ed.service.AppleIdentityTokenVerifier;
+import com.lucasxf.ed.service.AppleIdentityTokenVerifier.AppleUserInfo;
 import com.lucasxf.ed.service.GoogleTokenVerifierService;
 import com.lucasxf.ed.service.GoogleTokenVerifierService.GoogleUserInfo;
 import org.junit.jupiter.api.AfterAll;
@@ -102,6 +104,9 @@ class AuthIntegrationTest {
 
     @MockitoBean
     private GoogleTokenVerifierService googleTokenVerifier;
+
+    @MockitoBean
+    private AppleIdentityTokenVerifier appleIdentityTokenVerifier;
 
     // =====================================================================
     // Email / password flows
@@ -342,6 +347,174 @@ class AuthIntegrationTest {
                 .andExpect(jsonPath("$.refreshToken").doesNotExist())
                 .andExpect(cookie().exists("access_token"))
                 .andExpect(cookie().exists("refresh_token"));
+        }
+    }
+
+    // =====================================================================
+    // Sign in with Apple flows
+    // =====================================================================
+
+    @Nested
+    @DisplayName("Sign in with Apple flows")
+    class AppleAuth {
+
+        @Test
+        @DisplayName("new Apple user end-to-end: /apple → requiresHandle=true → /apple/complete → tokens, user in DB")
+        void appleSignup_shouldPersistUserInDb() throws Exception {
+            assumeTrue(DockerClientFactory.instance().isDockerAvailable(),
+                "Docker not available, skipping integration test");
+
+            String suffix = UUID.randomUUID().toString().substring(0, 8);
+            String email = "apple-" + suffix + "@privaterelay.appleid.com";
+            String appleSub = "apple-sub-" + suffix;
+            String handle = "apple" + suffix;
+            String identityToken = "apple-id-token-" + suffix;
+
+            when(appleIdentityTokenVerifier.verify(identityToken))
+                .thenReturn(new AppleUserInfo(appleSub, email));
+
+            // Step 1: new user — should receive a temp token and email for handle selection
+            String step1Body = mockMvc.perform(post("/api/v1/auth/mobile/apple")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""
+                        { "identityToken": "%s" }
+                        """.formatted(identityToken)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.requiresHandle").value(true))
+                .andExpect(jsonPath("$.tempToken").isNotEmpty())
+                .andExpect(jsonPath("$.email").value(email))
+                .andReturn().getResponse().getContentAsString();
+
+            String tempToken = extractField(step1Body, "tempToken");
+
+            // Step 2: complete sign-up — should create user and return tokens in body (mobile endpoint)
+            mockMvc.perform(post("/api/v1/auth/mobile/apple/complete")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""
+                        {
+                            "tempToken": "%s",
+                            "handle": "%s",
+                            "displayName": "Apple User"
+                        }
+                        """.formatted(tempToken, handle)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.requiresHandle").value(false))
+                .andExpect(jsonPath("$.handle").value(handle))
+                .andExpect(jsonPath("$.accessToken").isNotEmpty())
+                .andExpect(jsonPath("$.refreshToken").isNotEmpty());
+
+            assertThat(userRepository.findByEmail(email))
+                .isPresent()
+                .hasValueSatisfying(user -> {
+                    assertThat(user.getHandle()).isEqualTo(handle);
+                    assertThat(user.getAuthProvider()).isEqualTo("apple");
+                    assertThat(user.getPasswordHash()).isNull();
+                });
+        }
+
+        @Test
+        @DisplayName("returning Apple user should receive full tokens without handle selection")
+        void appleLogin_shouldReturnTokensForExistingUser() throws Exception {
+            assumeTrue(DockerClientFactory.instance().isDockerAvailable(),
+                "Docker not available, skipping integration test");
+
+            String suffix = UUID.randomUUID().toString().substring(0, 8);
+            String email = "apple2-" + suffix + "@privaterelay.appleid.com";
+            String appleSub = "apple-sub2-" + suffix;
+            String handle = "apple2" + suffix;
+
+            // Set up: create the user via sign-up flow
+            String setupToken = "apple-setup-token-" + suffix;
+            when(appleIdentityTokenVerifier.verify(setupToken))
+                .thenReturn(new AppleUserInfo(appleSub, email));
+
+            String setupBody = mockMvc.perform(post("/api/v1/auth/mobile/apple")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""
+                        { "identityToken": "%s" }
+                        """.formatted(setupToken)))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+
+            String tempToken = extractField(setupBody, "tempToken");
+
+            mockMvc.perform(post("/api/v1/auth/mobile/apple/complete")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""
+                        {
+                            "tempToken": "%s",
+                            "handle": "%s",
+                            "displayName": "Apple User 2"
+                        }
+                        """.formatted(tempToken, handle)))
+                .andExpect(status().isOk());
+
+            // Now login as returning user — should get full tokens, no handle required
+            String loginToken = "apple-login-token-" + suffix;
+            when(appleIdentityTokenVerifier.verify(loginToken))
+                .thenReturn(new AppleUserInfo(appleSub, email));
+
+            mockMvc.perform(post("/api/v1/auth/mobile/apple")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""
+                        { "identityToken": "%s" }
+                        """.formatted(loginToken)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.requiresHandle").value(false))
+                .andExpect(jsonPath("$.handle").value(handle))
+                .andExpect(jsonPath("$.accessToken").isNotEmpty())
+                .andExpect(jsonPath("$.refreshToken").isNotEmpty());
+        }
+
+        @Test
+        @DisplayName("Apple login with email already registered via Google should return 409")
+        void appleLogin_conflictWithGoogleAccount() throws Exception {
+            assumeTrue(DockerClientFactory.instance().isDockerAvailable(),
+                "Docker not available, skipping integration test");
+
+            String suffix = UUID.randomUUID().toString().substring(0, 8);
+            String email = "conflict-" + suffix + "@gmail.com";
+            String googleSub = "google-sub-" + suffix;
+            String appleSub = "apple-sub-" + suffix;
+            String handle = "conflict" + suffix;
+
+            // Set up: create a Google user with this email
+            String googleSetupToken = "google-setup-" + suffix;
+            when(googleTokenVerifier.verify(googleSetupToken))
+                .thenReturn(new GoogleUserInfo(googleSub, email, "Conflict User"));
+
+            String googleSetupBody = mockMvc.perform(post("/api/v1/auth/google")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""
+                        { "idToken": "%s" }
+                        """.formatted(googleSetupToken)))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+
+            String tempToken = extractField(googleSetupBody, "tempToken");
+
+            mockMvc.perform(post("/api/v1/auth/google/complete")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""
+                        {
+                            "tempToken": "%s",
+                            "handle": "%s",
+                            "displayName": "Conflict User"
+                        }
+                        """.formatted(tempToken, handle)))
+                .andExpect(status().isOk());
+
+            // Now attempt Apple login with the same email — should get 409
+            String appleToken = "apple-conflict-" + suffix;
+            when(appleIdentityTokenVerifier.verify(appleToken))
+                .thenReturn(new AppleUserInfo(appleSub, email));
+
+            mockMvc.perform(post("/api/v1/auth/mobile/apple")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""
+                        { "identityToken": "%s" }
+                        """.formatted(appleToken)))
+                .andExpect(status().isConflict());
         }
     }
 

--- a/backend/src/test/java/com/lucasxf/ed/service/AppleIdentityTokenVerifierTest.java
+++ b/backend/src/test/java/com/lucasxf/ed/service/AppleIdentityTokenVerifierTest.java
@@ -1,0 +1,186 @@
+package com.lucasxf.ed.service;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.lucasxf.ed.exception.AuthenticationException;
+import io.jsonwebtoken.Jwts;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link AppleIdentityTokenVerifier}.
+ *
+ * @author Lucas Xavier Ferreira
+ * @since 2026-04-18
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AppleIdentityTokenVerifier")
+class AppleIdentityTokenVerifierTest {
+
+    private static final String KID = "test-key-id";
+    private static final String SUBJECT = "000123.abc456def789.0001";
+    private static final String EMAIL = "user@privaterelay.appleid.com";
+
+    @Mock
+    private AppleJwkCache appleJwkCache;
+
+    private AppleIdentityTokenVerifier verifier;
+    private RSAPublicKey publicKey;
+    private RSAPrivateKey privateKey;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        KeyPairGenerator gen = KeyPairGenerator.getInstance("RSA");
+        gen.initialize(2048);
+        KeyPair pair = gen.generateKeyPair();
+        publicKey = (RSAPublicKey) pair.getPublic();
+        privateKey = (RSAPrivateKey) pair.getPrivate();
+        verifier = new AppleIdentityTokenVerifier(appleJwkCache, new ObjectMapper());
+    }
+
+    private String buildToken(String kid, String iss, List<String> aud, String sub,
+                              String email, Date expiry, RSAPrivateKey signingKey) {
+        var builder = Jwts.builder()
+            .header().add("kid", kid).and()
+            .issuer(iss)
+            .audience().add(aud).and()
+            .subject(sub)
+            .claim("email", email)
+            .issuedAt(new Date())
+            .expiration(expiry)
+            .signWith(signingKey);
+        return builder.compact();
+    }
+
+    private Date futureDate(int seconds) {
+        return new Date(System.currentTimeMillis() + seconds * 1_000L);
+    }
+
+    private Date pastDate(int seconds) {
+        return new Date(System.currentTimeMillis() - seconds * 1_000L);
+    }
+
+    @Nested
+    @DisplayName("verify — happy path")
+    class HappyPath {
+
+        @Test
+        @DisplayName("valid token → returns correct AppleUserInfo")
+        void verify_validToken_returnsUserInfo() {
+            String token = buildToken(KID, "https://appleid.apple.com",
+                List.of("net.learnimo.app"), SUBJECT, EMAIL, futureDate(3600), privateKey);
+            when(appleJwkCache.getKeys()).thenReturn(Map.of(KID, publicKey));
+
+            AppleIdentityTokenVerifier.AppleUserInfo info = verifier.verify(token);
+
+            assertThat(info.sub()).isEqualTo(SUBJECT);
+            assertThat(info.email()).isEqualTo(EMAIL);
+        }
+    }
+
+    @Nested
+    @DisplayName("verify — failure cases")
+    class FailureCases {
+
+        @Test
+        @DisplayName("expired token → throws AuthenticationException")
+        void verify_expiredToken_throws() {
+            String token = buildToken(KID, "https://appleid.apple.com",
+                List.of("net.learnimo.app"), SUBJECT, EMAIL, pastDate(60), privateKey);
+            when(appleJwkCache.getKeys()).thenReturn(Map.of(KID, publicKey));
+
+            assertThatThrownBy(() -> verifier.verify(token))
+                .isInstanceOf(AuthenticationException.class);
+        }
+
+        @Test
+        @DisplayName("wrong issuer → throws AuthenticationException")
+        void verify_wrongIssuer_throws() {
+            String token = buildToken(KID, "https://evil.example.com",
+                List.of("net.learnimo.app"), SUBJECT, EMAIL, futureDate(3600), privateKey);
+            when(appleJwkCache.getKeys()).thenReturn(Map.of(KID, publicKey));
+
+            assertThatThrownBy(() -> verifier.verify(token))
+                .isInstanceOf(AuthenticationException.class)
+                .hasMessageContaining("Invalid issuer");
+        }
+
+        @Test
+        @DisplayName("wrong audience → throws AuthenticationException")
+        void verify_wrongAudience_throws() {
+            String token = buildToken(KID, "https://appleid.apple.com",
+                List.of("com.other.app"), SUBJECT, EMAIL, futureDate(3600), privateKey);
+            when(appleJwkCache.getKeys()).thenReturn(Map.of(KID, publicKey));
+
+            assertThatThrownBy(() -> verifier.verify(token))
+                .isInstanceOf(AuthenticationException.class)
+                .hasMessageContaining("Invalid audience");
+        }
+
+        @Test
+        @DisplayName("tampered signature → throws AuthenticationException")
+        void verify_tamperedSignature_throws() {
+            String token = buildToken(KID, "https://appleid.apple.com",
+                List.of("net.learnimo.app"), SUBJECT, EMAIL, futureDate(3600), privateKey);
+            // Tamper: replace the signature part with garbage
+            String[] parts = token.split("\\.");
+            String tampered = parts[0] + "." + parts[1] + ".invalidsignatureXXX";
+            when(appleJwkCache.getKeys()).thenReturn(Map.of(KID, publicKey));
+
+            assertThatThrownBy(() -> verifier.verify(tampered))
+                .isInstanceOf(AuthenticationException.class);
+        }
+
+        @Test
+        @DisplayName("unknown kid → throws AuthenticationException")
+        void verify_unknownKid_throws() {
+            String token = buildToken("unknown-kid", "https://appleid.apple.com",
+                List.of("net.learnimo.app"), SUBJECT, EMAIL, futureDate(3600), privateKey);
+            when(appleJwkCache.getKeys()).thenReturn(Map.of(KID, publicKey));
+
+            assertThatThrownBy(() -> verifier.verify(token))
+                .isInstanceOf(AuthenticationException.class)
+                .hasMessageContaining("Unknown key ID");
+        }
+    }
+
+    @Nested
+    @DisplayName("JWK cache interaction")
+    class CacheInteraction {
+
+        @Test
+        @DisplayName("second verification reuses cached keys — getKeys called once per verify")
+        void verify_twoCalls_jwkCacheCalledTwice() {
+            String token = buildToken(KID, "https://appleid.apple.com",
+                List.of("net.learnimo.app"), SUBJECT, EMAIL, futureDate(3600), privateKey);
+            when(appleJwkCache.getKeys()).thenReturn(Map.of(KID, publicKey));
+
+            verifier.verify(token);
+            verifier.verify(token);
+
+            // getKeys() is called once per verify() invocation; the cache itself handles
+            // the TTL-based deduplication internally (tested separately via AppleJwkCache).
+            // Here we confirm verifier delegates to the cache exactly once per call.
+            verify(appleJwkCache, times(2)).getKeys();
+        }
+    }
+}

--- a/backend/src/test/java/com/lucasxf/ed/service/AuthServiceAppleTest.java
+++ b/backend/src/test/java/com/lucasxf/ed/service/AuthServiceAppleTest.java
@@ -1,0 +1,258 @@
+package com.lucasxf.ed.service;
+
+import java.time.Duration;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import com.lucasxf.ed.domain.User;
+import com.lucasxf.ed.exception.InvalidTokenException;
+import com.lucasxf.ed.exception.ResourceConflictException;
+import com.lucasxf.ed.repository.RefreshTokenRepository;
+import com.lucasxf.ed.repository.UserRepository;
+import com.lucasxf.ed.service.AppleIdentityTokenVerifier.AppleUserInfo;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for Sign in with Apple methods in {@link AuthService}.
+ *
+ * @author Lucas Xavier Ferreira
+ * @since 2026-04-18
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AuthService — Sign in with Apple")
+class AuthServiceAppleTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Mock
+    private JwtService jwtService;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @Mock
+    private GoogleTokenVerifierService googleTokenVerifier;
+
+    @Mock
+    private AppleIdentityTokenVerifier appleIdentityTokenVerifier;
+
+    private AuthService authService;
+
+    @BeforeEach
+    void setUp() {
+        authService = new AuthService(
+            userRepository, refreshTokenRepository, jwtService,
+            passwordEncoder, googleTokenVerifier, appleIdentityTokenVerifier
+        );
+    }
+
+    @Nested
+    @DisplayName("appleLogin")
+    class AppleLogin {
+
+        @Test
+        @DisplayName("should return auth tokens for existing Apple user found by appleSub")
+        void appleLogin_existingAppleUserBySub() {
+            var userInfo = new AppleUserInfo("apple-sub-123", "alice@privaterelay.appleid.com");
+            when(appleIdentityTokenVerifier.verify("valid-identity-token")).thenReturn(userInfo);
+
+            var user = new User("alice@privaterelay.appleid.com", null, "Alice Smith", "alice");
+            user.setAuthProvider("apple");
+            user.setAppleSub("apple-sub-123");
+            when(userRepository.findByAppleSub("apple-sub-123")).thenReturn(Optional.of(user));
+
+            when(jwtService.generateAccessToken(any(), anyString(), anyString()))
+                .thenReturn("access-token");
+            when(jwtService.generateRefreshToken()).thenReturn("refresh-token");
+            when(jwtService.hashRefreshToken("refresh-token")).thenReturn("hashed");
+            when(jwtService.getRefreshTokenExpiry()).thenReturn(Duration.ofDays(7));
+
+            AppleLoginResult result = authService.appleLogin("valid-identity-token");
+
+            assertThat(result).isInstanceOf(AppleLoginResult.ExistingUser.class);
+            AppleLoginResult.ExistingUser existing = (AppleLoginResult.ExistingUser) result;
+            assertThat(existing.authResult().accessToken()).isEqualTo("access-token");
+            assertThat(existing.authResult().refreshToken()).isEqualTo("refresh-token");
+            assertThat(existing.authResult().handle()).isEqualTo("alice");
+        }
+
+        @Test
+        @DisplayName("should find existing Apple user by email when appleSub lookup misses")
+        void appleLogin_existingAppleUserByEmail() {
+            var userInfo = new AppleUserInfo("apple-sub-456", "bob@example.com");
+            when(appleIdentityTokenVerifier.verify("valid-identity-token")).thenReturn(userInfo);
+
+            // sub lookup misses
+            when(userRepository.findByAppleSub("apple-sub-456")).thenReturn(Optional.empty());
+
+            // email lookup hits
+            var user = new User("bob@example.com", null, "Bob Smith", "bob");
+            user.setAuthProvider("apple");
+            user.setAppleSub("apple-sub-456");
+            when(userRepository.findByEmail("bob@example.com")).thenReturn(Optional.of(user));
+
+            when(jwtService.generateAccessToken(any(), anyString(), anyString()))
+                .thenReturn("access-token");
+            when(jwtService.generateRefreshToken()).thenReturn("refresh-token");
+            when(jwtService.hashRefreshToken("refresh-token")).thenReturn("hashed");
+            when(jwtService.getRefreshTokenExpiry()).thenReturn(Duration.ofDays(7));
+
+            AppleLoginResult result = authService.appleLogin("valid-identity-token");
+
+            assertThat(result).isInstanceOf(AppleLoginResult.ExistingUser.class);
+            AppleLoginResult.ExistingUser existing = (AppleLoginResult.ExistingUser) result;
+            assertThat(existing.authResult().handle()).isEqualTo("bob");
+        }
+
+        @Test
+        @DisplayName("should return temp token for new Apple user")
+        void appleLogin_newUser() {
+            var userInfo = new AppleUserInfo("apple-sub-new", "charlie@example.com");
+            when(appleIdentityTokenVerifier.verify("valid-identity-token")).thenReturn(userInfo);
+            when(userRepository.findByAppleSub("apple-sub-new")).thenReturn(Optional.empty());
+            when(userRepository.findByEmail("charlie@example.com")).thenReturn(Optional.empty());
+            when(jwtService.generateAppleTempToken("apple-sub-new", "charlie@example.com"))
+                .thenReturn("apple-temp-token");
+
+            AppleLoginResult result = authService.appleLogin("valid-identity-token");
+
+            assertThat(result).isInstanceOf(AppleLoginResult.NewUser.class);
+            AppleLoginResult.NewUser newUser = (AppleLoginResult.NewUser) result;
+            assertThat(newUser.tempToken()).isEqualTo("apple-temp-token");
+            assertThat(newUser.email()).isEqualTo("charlie@example.com");
+            verify(userRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("should throw 409 when Apple email matches a local auth user")
+        void appleLogin_emailConflictWithLocal() {
+            var userInfo = new AppleUserInfo("apple-sub-conflict", "dave@example.com");
+            when(appleIdentityTokenVerifier.verify("valid-identity-token")).thenReturn(userInfo);
+            when(userRepository.findByAppleSub("apple-sub-conflict")).thenReturn(Optional.empty());
+
+            var localUser = new User("dave@example.com", "hashed-pw", "Dave", "dave");
+            // authProvider defaults to "local"
+            when(userRepository.findByEmail("dave@example.com")).thenReturn(Optional.of(localUser));
+
+            assertThatThrownBy(() -> authService.appleLogin("valid-identity-token"))
+                .isInstanceOf(ResourceConflictException.class)
+                .hasMessageContaining("already registered with a different sign-in method");
+        }
+
+        @Test
+        @DisplayName("should throw 409 when Apple email matches a Google auth user")
+        void appleLogin_emailConflictWithGoogle() {
+            var userInfo = new AppleUserInfo("apple-sub-conflict", "eve@gmail.com");
+            when(appleIdentityTokenVerifier.verify("valid-identity-token")).thenReturn(userInfo);
+            when(userRepository.findByAppleSub("apple-sub-conflict")).thenReturn(Optional.empty());
+
+            var googleUser = new User("eve@gmail.com", null, "Eve", "eve");
+            googleUser.setAuthProvider("google");
+            when(userRepository.findByEmail("eve@gmail.com")).thenReturn(Optional.of(googleUser));
+
+            assertThatThrownBy(() -> authService.appleLogin("valid-identity-token"))
+                .isInstanceOf(ResourceConflictException.class)
+                .hasMessageContaining("already registered with a different sign-in method");
+        }
+    }
+
+    @Nested
+    @DisplayName("completeAppleSignup")
+    class CompleteAppleSignup {
+
+        @Test
+        @DisplayName("should create user and return auth tokens")
+        void completeAppleSignup_success() {
+            Claims claims = Jwts.claims()
+                .add("type", "apple_signup")
+                .add("appleSub", "apple-sub-123")
+                .add("email", "frank@example.com")
+                .build();
+
+            when(jwtService.parseAppleTempToken("apple-temp-token")).thenReturn(claims);
+            when(userRepository.existsByHandle("franksmith")).thenReturn(false);
+            when(userRepository.save(any(User.class))).thenAnswer(inv -> inv.getArgument(0));
+            when(jwtService.generateAccessToken(any(), anyString(), anyString()))
+                .thenReturn("access-token");
+            when(jwtService.generateRefreshToken()).thenReturn("refresh-token");
+            when(jwtService.hashRefreshToken("refresh-token")).thenReturn("hashed");
+            when(jwtService.getRefreshTokenExpiry()).thenReturn(Duration.ofDays(7));
+
+            AuthResult result = authService.completeAppleSignup(
+                "apple-temp-token", "franksmith", "Frank S"
+            );
+
+            assertThat(result.accessToken()).isEqualTo("access-token");
+            assertThat(result.handle()).isEqualTo("franksmith");
+
+            ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
+            verify(userRepository).save(userCaptor.capture());
+            User savedUser = userCaptor.getValue();
+            assertThat(savedUser.getEmail()).isEqualTo("frank@example.com");
+            assertThat(savedUser.getPasswordHash()).isNull();
+            assertThat(savedUser.getAuthProvider()).isEqualTo("apple");
+            assertThat(savedUser.getAppleSub()).isEqualTo("apple-sub-123");
+            assertThat(savedUser.getDisplayName()).isEqualTo("Frank S");
+            assertThat(savedUser.getHandle()).isEqualTo("franksmith");
+        }
+
+        @Test
+        @DisplayName("should throw when handle is already taken")
+        void completeAppleSignup_handleTaken() {
+            Claims claims = Jwts.claims()
+                .add("type", "apple_signup")
+                .add("appleSub", "apple-sub-123")
+                .add("email", "frank@example.com")
+                .build();
+
+            when(jwtService.parseAppleTempToken("apple-temp-token")).thenReturn(claims);
+            when(userRepository.existsByHandle("taken")).thenReturn(true);
+
+            assertThatThrownBy(() -> authService.completeAppleSignup(
+                "apple-temp-token", "taken", "Frank Smith"
+            ))
+                .isInstanceOf(ResourceConflictException.class)
+                .hasMessageContaining("Handle already taken");
+
+            verify(userRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("should throw when temp token is expired or invalid")
+        void completeAppleSignup_expiredToken() {
+            when(jwtService.parseAppleTempToken("expired-token"))
+                .thenThrow(new InvalidTokenException("Invalid or expired temp token"));
+
+            assertThatThrownBy(() -> authService.completeAppleSignup(
+                "expired-token", "handle", "Name"
+            ))
+                .isInstanceOf(InvalidTokenException.class)
+                .hasMessageContaining("Invalid or expired temp token");
+
+            verify(userRepository, never()).save(any());
+        }
+    }
+}

--- a/backend/src/test/java/com/lucasxf/ed/service/AuthServiceGoogleTest.java
+++ b/backend/src/test/java/com/lucasxf/ed/service/AuthServiceGoogleTest.java
@@ -56,13 +56,16 @@ class AuthServiceGoogleTest {
     @Mock
     private GoogleTokenVerifierService googleTokenVerifier;
 
+    @Mock
+    private AppleIdentityTokenVerifier appleIdentityTokenVerifier;
+
     private AuthService authService;
 
     @BeforeEach
     void setUp() {
         authService = new AuthService(
             userRepository, refreshTokenRepository, jwtService,
-            passwordEncoder, googleTokenVerifier
+            passwordEncoder, googleTokenVerifier, appleIdentityTokenVerifier
         );
     }
 

--- a/backend/src/test/java/com/lucasxf/ed/service/AuthServiceTest.java
+++ b/backend/src/test/java/com/lucasxf/ed/service/AuthServiceTest.java
@@ -54,13 +54,16 @@ class AuthServiceTest {
     @Mock
     private GoogleTokenVerifierService googleTokenVerifier;
 
+    @Mock
+    private AppleIdentityTokenVerifier appleIdentityTokenVerifier;
+
     private AuthService authService;
 
     @BeforeEach
     void setUp() {
         authService = new AuthService(
             userRepository, refreshTokenRepository, jwtService,
-            passwordEncoder, googleTokenVerifier
+            passwordEncoder, googleTokenVerifier, appleIdentityTokenVerifier
         );
     }
 

--- a/docs/ROADMAP.phase-1.md
+++ b/docs/ROADMAP.phase-1.md
@@ -19,6 +19,7 @@
 | 1.1.3 | Google OAuth login | ✅ Backend + Web (PR #20) |
 | 1.1.4 | JWT session management | ✅ Backend (PR #15) + Web (PR #17) |
 | 1.1.5 | Password reset flow | ✅ Implemented (2026-02-21) |
+| 1.1.6 | Sign in with Apple (mobile) | ✅ Backend + Mobile (feat/sign-in-with-apple, 2026-04-18) |
 
 ### Milestone 1.2: POK CRUD ✅
 

--- a/docs/specs/features/sign-in-with-apple.md
+++ b/docs/specs/features/sign-in-with-apple.md
@@ -1,0 +1,421 @@
+# Sign in with Apple
+
+> **Status:** Approved
+> **Created:** 2026-04-17
+> **Implemented:** _pending_
+
+---
+
+## Context
+
+Apple rejected the learnimo iOS submission on 2026-04-17 under **Guideline 4.8 (Sign in with Apple)**: an app that offers a third-party login option (Google Sign-In) must also offer Sign in with Apple as an equivalent option for users who prefer it. This is a hard App Store gate — no waiver is available.
+
+Sign in with Apple also provides a meaningful UX benefit: users can hide their real email address behind Apple's private relay, reducing the friction of sharing personal data with a new app.
+
+This spec covers the full implementation: backend identity-token verification, new API endpoints (mirroring the existing Google OAuth flow), iOS mobile UI using Apple's mandatory native button, and a privacy-policy update.
+
+**Related:**
+- App Store rejection report: `mobile/store-assets/reviews/2026-04-17-app-store-connect-review.md`
+- Remediation plan: `docs/plans/apple-rejection-2026-04-17.md`
+- Mirror spec (Google OAuth, mobile): `docs/specs/features/mobile-google-oauth.md`
+
+---
+
+## Requirements
+
+### Functional
+
+- [ ] **FR1** *(Must Have)* — The backend verifies Apple identity tokens (JWTs) by fetching Apple's JWK set from `https://appleid.apple.com/auth/keys`, caching it for 15 minutes, and validating `iss`, `aud`, expiry, and RS256 signature.
+- [ ] **FR2** *(Must Have)* — `POST /api/v1/auth/mobile/apple` accepts `{ identityToken }`. If the `apple_sub` matches an existing user, returns a JWT pair (same `AuthResponse` shape as login). If the user is new, returns `{ requiresHandle: true, tempToken, email }`.
+- [ ] **FR3** *(Must Have)* — `POST /api/v1/auth/mobile/apple/complete` accepts `{ tempToken, handle, displayName }`, creates the user account with `auth_provider='apple'`, and returns a JWT pair.
+- [ ] **FR4** *(Must Have)* — A Flyway V23 migration adds `apple_sub VARCHAR(255) UNIQUE NULL` to the `users` table.
+- [ ] **FR5** *(Must Have)* — Returning users are looked up by `apple_sub` first (more reliable than email, since Apple relay addresses can change). Email lookup is a fallback only.
+- [ ] **FR6** *(Must Have)* — Apple's "Hide My Email" relay addresses (format `random@privaterelay.appleid.com`) are stored as-is; no special normalization. The flow is identical to real email.
+- [ ] **FR7** *(Must Have)* — If the provided email already belongs to a `local` or `google` account, respond 409 Conflict with a user-readable message.
+- [ ] **FR8** *(Must Have)* — On iOS, the `AppleSignInButton` is shown above the Google Sign-In button on both `LoginScreen` and `RegisterScreen`, using Apple's mandatory native `AppleAuthenticationButton` component.
+- [ ] **FR9** *(Must Have)* — On Android (and any non-iOS platform), the `AppleSignInButton` renders `null` — no button, no divider, no error.
+- [ ] **FR10** *(Must Have)* — `ChooseHandleScreen` handles Apple signup completion (passing `appleSub` and `email` from the temp token) alongside the existing Google path — no screen UI changes required.
+- [ ] **FR11** *(Must Have)* — i18n keys for Apple sign-in labels in both `en.ts` and `pt-BR.ts`.
+- [ ] **FR12** *(Should Have)* — The privacy policy page (`web/src/app/[locale]/privacy/page.tsx`) gains a paragraph describing what data Sign in with Apple shares with learnimo and how it is used.
+
+**Scope:** `backend + mobile` (privacy policy touches `web` but is a minor content edit, not a new feature)
+
+### Non-Functional
+
+- [ ] **NFR1** — JWK cache TTL is 15 minutes; a cache miss must not block the request for more than 3 seconds.
+- [ ] **NFR2** — No Apple ID, Team ID, Key ID, or `.p8` key material is ever committed to any git-tracked file. All secrets are injected via environment variables.
+- [ ] **NFR3** — `AppleAuthenticationButton` uses Apple's native rendering; no custom colors, borders, or icon replacement is applied (custom styling = App Store rejection risk).
+- [ ] **NFR4** — Identity token validation is stateless — no Apple-side network call after initial JWK fetch.
+- [ ] **NFR5** — Backend unit test coverage must remain ≥ 90% (JaCoCo threshold); mobile coverage ≥ 80%.
+- [ ] **NFR6** — All user-facing strings are i18n-keyed; no hardcoded English in component JSX.
+
+---
+
+## Technical Constraints
+
+**Stack:** Backend (Java 21, Spring Boot 4) + Mobile (Expo SDK 53, React Native 0.79.6, TypeScript)
+
+**Technologies:**
+- Backend: Spring `RestClient` for JWK fetch; `java.security` (`KeyFactory`, `RSAPublicKeySpec`, `Signature`) for RS256 verification; JJWT 0.12.6 for temp-token generation/parsing (existing pattern). No new library dependencies.
+- Mobile: `expo-apple-authentication` (new package, iOS only); `Platform.OS === 'ios'` guard.
+
+**Integration Points:**
+- `AuthMobileController` — add two new endpoints mirroring the Google pair.
+- `AuthService` — add `appleLogin(identityToken)` and `completeAppleSignup(tempToken, handle, displayName)` methods.
+- `User` entity — add `apple_sub` field.
+- `UserRepository` — add `findByAppleSub(String)` and `existsByAppleSub(String)`.
+- Mobile `auth.ts` — add `appleLoginApi` and `completeAppleSignupApi` mirroring the Google pair.
+- Mobile `AuthStack.tsx` / `ChooseHandleScreen.tsx` — the temp token flow already handles Google; Apple uses identical params (`tempToken`, `email`) — no screen changes needed.
+
+**Apple Developer Console prerequisites (user-driven, before on-device verification):**
+- Sign in with Apple capability enabled on App ID `net.learnimo.app`.
+- `.p8` signing key downloaded; Team ID + Key ID recorded.
+- `APPLE_TEAM_ID`, `APPLE_KEY_ID` available as env vars (backend config reference only — not used for token verification, which is JWKS-based).
+
+**Out of Scope:**
+- Sign in with Apple on web (Apple 4.8 is iOS-only; web is a separate future feature).
+- Sign in with Apple on Android.
+- Server-side authorization code validation (this spec uses the identity token path only, consistent with the Google approach).
+- Account linking (connecting an existing email/password account to Apple — deferred).
+
+---
+
+## Acceptance Criteria
+
+### AC1: New user, full email
+**GIVEN** a user taps "Sign in with Apple" on `LoginScreen` or `RegisterScreen` on iOS  
+**AND** the user has never signed into learnimo before  
+**AND** the user allows sharing their real email  
+**WHEN** the iOS authentication sheet completes and the app sends the identity token to `POST /api/v1/auth/mobile/apple`  
+**THEN** the backend responds 200 with `{ requiresHandle: true, tempToken, email }`  
+**AND** the app navigates to `ChooseHandleScreen` with `tempToken` and `email`
+
+### AC2: New user, "Hide My Email"
+**GIVEN** the same setup as AC1  
+**AND** the user chooses "Hide My Email"  
+**WHEN** the app sends the identity token  
+**THEN** the backend responds 200 with `{ requiresHandle: true, tempToken, email }` where `email` is an `@privaterelay.appleid.com` address  
+**AND** the relay address is stored in `users.email` after `completeAppleSignup`
+
+### AC3: Returning user
+**GIVEN** a user has previously completed Apple sign-in  
+**WHEN** the user taps "Sign in with Apple" and the identity token is sent to `POST /api/v1/auth/mobile/apple`  
+**THEN** the backend responds 200 with a full JWT pair (`accessToken`, `refreshToken`)  
+**AND** the app calls `setUser()` and navigates to the Feed
+
+### AC4: iOS-only rendering
+**GIVEN** the app is running on Android  
+**WHEN** `LoginScreen` or `RegisterScreen` renders  
+**THEN** no "Sign in with Apple" button or divider is visible
+
+### AC5: User cancels Apple sheet
+**GIVEN** the user taps "Sign in with Apple"  
+**WHEN** the user cancels the iOS authentication sheet  
+**THEN** no error message is shown and the auth screen remains unchanged
+
+### AC6: Invalid / expired identity token
+**GIVEN** the app sends a malformed or expired Apple identity token  
+**WHEN** `POST /api/v1/auth/mobile/apple` receives it  
+**THEN** the backend responds 401  
+**AND** the mobile app shows `auth.errors.appleFailed`
+
+### AC7: Email conflict — existing local or Google account
+**GIVEN** a user's Apple email is already registered with `auth_provider='local'` or `auth_provider='google'`  
+**WHEN** `POST /api/v1/auth/mobile/apple` receives the identity token  
+**THEN** the backend responds 409 Conflict  
+**AND** the mobile app shows an error directing the user to sign in with email/password or Google
+
+### AC8: Handle registration via Apple temp token
+**GIVEN** a new Apple user is on `ChooseHandleScreen` with a valid Apple temp token  
+**WHEN** the user submits a handle  
+**THEN** `POST /api/v1/auth/mobile/apple/complete` is called  
+**AND** a user is created with `auth_provider='apple'` and `apple_sub` stored  
+**AND** the app navigates to the Feed
+
+### AC9: Backend JWK caching
+**GIVEN** the Apple JWK endpoint has been called once in the last 15 minutes  
+**WHEN** a second Apple identity token is verified  
+**THEN** no outbound HTTP call to `https://appleid.apple.com/auth/keys` is made
+
+### AC10: Privacy policy disclosure
+**GIVEN** a user visits the privacy policy page  
+**WHEN** they look for Sign in with Apple information  
+**THEN** a paragraph describes what data Apple shares (name, email or relay, stable sub) and how learnimo uses it
+
+---
+
+## Screens
+
+> _Mobile-only. No new screens — existing auth screens are modified._
+
+### Screen: LoginScreen (modified)
+
+**Purpose:** User signs in to an existing account. Apple button added above the Google button.
+
+**Route:** Mobile nav stack — `AuthStack > Login`
+
+**Layout (additions only):**
+1. After the primary submit button and before the Google divider: `<AppleSignInButton>` — iOS only, renders null on Android.
+
+**Components (additions):**
+- `LoginScreen` → `<AppleSignInButton>` (new, iOS-gated) → `AppleAuthenticationButton` (native)
+- `LoginScreen` → `useAppleAuth` (new hook)
+
+**States:**
+- iOS: Apple button renders above Google button
+- Android / non-iOS: Apple button absent (renders null, no gap)
+- Loading: native button uses Apple's built-in loading state
+
+**i18n:**
+| Key | EN | PT-BR |
+|-----|-----|-------|
+| `auth.login.appleButton` | Sign in with Apple | Entrar com Apple |
+| `auth.errors.appleFailed` | Sign in with Apple failed. Try again. | Falha ao entrar com Apple. Tente novamente. |
+
+**Interactions:**
+- Tap "Sign in with Apple" → iOS system sheet → success → Feed (existing user) or ChooseHandle (new user)
+- Cancel sheet → no-op, screen stays
+
+---
+
+### Screen: RegisterScreen (modified)
+
+**Purpose:** Same Apple button wiring as LoginScreen.
+
+**Layout / Components / i18n:** Identical additions to LoginScreen.
+
+---
+
+### Screen: ChooseHandleScreen (no changes)
+
+**Purpose:** Unchanged — already accepts `{ tempToken, email }` params from Google. Apple uses the same params; no screen modification needed.
+
+---
+
+## Implementation Approach
+
+### Architecture
+
+The feature mirrors the existing Google OAuth flow exactly:
+
+```
+Mobile (iOS)
+  └─ useAppleAuth hook
+       └─ expo-apple-authentication (native ASAuthorizationAppleIDRequest)
+            └─ identityToken (JWT signed by Apple)
+                 └─ appleLoginApi() → POST /auth/mobile/apple
+                      └─ AppleIdentityTokenVerifier.verify(identityToken)
+                           └─ AppleJwkCache (RestClient, 15 min TTL)
+                                └─ java.security RSAPublicKeySpec + JJWT parser
+                      └─ AuthService.appleLogin(identityToken)
+                           ├─ existing user (by apple_sub) → issueTokens()
+                           └─ new user → jwtService.generateTempToken()
+                                └─ mobile: ChooseHandleScreen
+                                     └─ completeAppleSignupApi() → POST /auth/mobile/apple/complete
+                                          └─ AuthService.completeAppleSignup()
+```
+
+**Apple JWK verification (pure-Java, no new dependencies):**
+1. `AppleJwkCache` fetches `https://appleid.apple.com/auth/keys` via Spring `RestClient` on first call and every 15 minutes thereafter. Returns a `Map<String, RSAPublicKey>` keyed by `kid`.
+2. `AppleIdentityTokenVerifier.verify(identityToken)`:
+   - Decode JWT header (Base64 URL decode, parse JSON) to extract `kid` and `alg`.
+   - Look up matching `RSAPublicKey` from cache by `kid`.
+   - Use JJWT `Jwts.parser().verifyWith(publicKey).build().parseSignedClaims(token)` for signature + expiry.
+   - Assert `iss == "https://appleid.apple.com"`.
+   - Assert `aud` contains `"net.learnimo.app"` (bundle ID).
+   - Return `AppleUserInfo(sub, email)` — `name` is optional (Apple only sends it on first login).
+
+**UserRepository lookup order (FR5):**
+```java
+// 1. Try apple_sub — stable, never changes even if relay email rotates
+userRepository.findByAppleSub(userInfo.sub())
+  .orElseGet(() ->
+    // 2. Fall back to email — covers edge case of first login before sub was stored
+    userRepository.findByEmail(normalizedEmail).orElse(null)
+  )
+```
+
+**`auth_provider` values:** `"local"` | `"google"` | `"apple"` — string column, consistent with existing design.
+
+### Test Strategy
+
+- [ ] **Partial TDD** — `AppleIdentityTokenVerifier` unit tests written first; integration tests written alongside endpoint implementation.
+
+**Backend:**
+- `AppleIdentityTokenVerifierTest` — valid token, expired token, wrong `iss`, wrong `aud`, tampered signature, unknown `kid`, JWK cache hit vs miss.
+- `AuthServiceAppleTest` — existing user by `apple_sub`, new user → temp token, email conflict (local), email conflict (google).
+- `AuthMobileControllerAppleTest` — `POST /apple`: 200 existing, 200 new, 401 invalid token, 409 conflict. `POST /apple/complete`: 200, 409 handle taken.
+- `AuthIntegrationTest` (extend) — Apple new user end-to-end, returning user, conflict.
+
+**Mobile:**
+- `useAppleAuth.test.ts` — cancelled, error, existing user success (`setUser` called), new user success (navigate to ChooseHandle).
+- `AppleSignInButton.test.tsx` — renders on iOS, returns null on Android.
+- `LoginScreen.test.tsx` — Apple button present on iOS, absent on Android.
+- `RegisterScreen.test.tsx` — same.
+
+### File Changes
+
+**New (backend):**
+- `backend/src/main/java/com/lucasxf/ed/service/AppleJwkCache.java`
+- `backend/src/main/java/com/lucasxf/ed/service/AppleIdentityTokenVerifier.java`
+- `backend/src/main/java/com/lucasxf/ed/service/AppleLoginResult.java`
+- `backend/src/main/java/com/lucasxf/ed/dto/AppleLoginRequest.java`
+- `backend/src/main/java/com/lucasxf/ed/dto/AppleLoginResponse.java`
+- `backend/src/main/java/com/lucasxf/ed/dto/CompleteAppleSignupRequest.java`
+- `backend/src/main/resources/db/migration/V23__add_apple_sub_to_users.sql`
+- `backend/src/test/java/com/lucasxf/ed/service/AppleIdentityTokenVerifierTest.java`
+- `backend/src/test/java/com/lucasxf/ed/service/AuthServiceAppleTest.java`
+- `backend/src/test/java/com/lucasxf/ed/controller/AuthMobileControllerAppleTest.java`
+
+**Modified (backend):**
+- `backend/src/main/java/com/lucasxf/ed/domain/User.java`
+- `backend/src/main/java/com/lucasxf/ed/repository/UserRepository.java`
+- `backend/src/main/java/com/lucasxf/ed/service/AuthService.java`
+- `backend/src/main/java/com/lucasxf/ed/controller/AuthMobileController.java`
+- `backend/src/test/java/com/lucasxf/ed/integration/AuthIntegrationTest.java`
+
+**New (mobile):**
+- `mobile/src/hooks/useAppleAuth.ts`
+- `mobile/src/components/auth/AppleSignInButton.tsx`
+- `mobile/src/hooks/__tests__/useAppleAuth.test.ts`
+- `mobile/src/components/auth/__tests__/AppleSignInButton.test.tsx`
+
+**Modified (mobile):**
+- `mobile/package.json`
+- `mobile/app.json`
+- `mobile/src/lib/auth.ts`
+- `mobile/src/screens/auth/LoginScreen.tsx`
+- `mobile/src/screens/auth/RegisterScreen.tsx`
+- `mobile/src/i18n/locales/en.ts`
+- `mobile/src/i18n/locales/pt-BR.ts`
+- `mobile/src/screens/auth/__tests__/LoginScreen.test.tsx`
+- `mobile/src/screens/auth/__tests__/RegisterScreen.test.tsx`
+
+**Modified (web):**
+- `web/src/app/[locale]/privacy/page.tsx`
+
+**Migrations:**
+- `backend/src/main/resources/db/migration/V23__add_apple_sub_to_users.sql`
+
+```sql
+ALTER TABLE users
+  ADD COLUMN apple_sub VARCHAR(255) NULL;
+
+CREATE UNIQUE INDEX users_apple_sub_unique
+  ON users (apple_sub)
+  WHERE apple_sub IS NOT NULL;
+```
+
+---
+
+## Implementation Plan
+
+### Task 1: Flyway migration + User entity + UserRepository
+- **Files:**
+  - `backend/src/main/resources/db/migration/V23__add_apple_sub_to_users.sql`
+  - `backend/src/main/java/com/lucasxf/ed/domain/User.java`
+  - `backend/src/main/java/com/lucasxf/ed/repository/UserRepository.java`
+- **Depends on:** _none_
+- **Commit:** `feat(backend): add apple_sub column to users (V23 migration)`
+- **Stack:** backend
+
+### Task 2: AppleJwkCache + AppleIdentityTokenVerifier + unit tests
+- **Files:**
+  - `backend/src/main/java/com/lucasxf/ed/service/AppleJwkCache.java`
+  - `backend/src/main/java/com/lucasxf/ed/service/AppleIdentityTokenVerifier.java`
+  - `backend/src/test/java/com/lucasxf/ed/service/AppleIdentityTokenVerifierTest.java`
+- **Depends on:** _none_
+- **Commit:** `feat(backend): add Apple identity token verifier with JWK cache`
+- **Stack:** backend
+
+### Task 3: DTOs + AppleLoginResult + AuthService apple methods + unit tests
+- **Files:**
+  - `backend/src/main/java/com/lucasxf/ed/dto/AppleLoginRequest.java`
+  - `backend/src/main/java/com/lucasxf/ed/dto/AppleLoginResponse.java`
+  - `backend/src/main/java/com/lucasxf/ed/dto/CompleteAppleSignupRequest.java`
+  - `backend/src/main/java/com/lucasxf/ed/service/AppleLoginResult.java`
+  - `backend/src/main/java/com/lucasxf/ed/service/AuthService.java`
+  - `backend/src/test/java/com/lucasxf/ed/service/AuthServiceAppleTest.java`
+- **Depends on:** Task 1, Task 2
+- **Commit:** `feat(backend): add appleLogin and completeAppleSignup to AuthService`
+- **Stack:** backend
+
+### Task 4: AuthMobileController endpoints + controller tests + integration tests
+- **Files:**
+  - `backend/src/main/java/com/lucasxf/ed/controller/AuthMobileController.java`
+  - `backend/src/test/java/com/lucasxf/ed/controller/AuthMobileControllerAppleTest.java`
+  - `backend/src/test/java/com/lucasxf/ed/integration/AuthIntegrationTest.java`
+- **Depends on:** Task 3
+- **Commit:** `feat(backend): add POST /auth/mobile/apple and /apple/complete endpoints`
+- **Stack:** backend
+
+### Task 5: Mobile — install expo-apple-authentication + app.json plugin
+- **Files:**
+  - `mobile/package.json`
+  - `mobile/app.json`
+- **Depends on:** _none_
+- **Commit:** `feat(mobile): install expo-apple-authentication and register plugin`
+- **Stack:** mobile
+
+### Task 6: Mobile — auth.ts API functions + useAppleAuth hook + i18n + hook tests
+- **Files:**
+  - `mobile/src/lib/auth.ts`
+  - `mobile/src/hooks/useAppleAuth.ts`
+  - `mobile/src/i18n/locales/en.ts`
+  - `mobile/src/i18n/locales/pt-BR.ts`
+  - `mobile/src/hooks/__tests__/useAppleAuth.test.ts`
+- **Depends on:** Task 5
+- **Commit:** `feat(mobile): add appleLoginApi, useAppleAuth hook, and i18n keys`
+- **Stack:** mobile
+
+### Task 7: Mobile — AppleSignInButton + LoginScreen + RegisterScreen wiring + tests
+- **Files:**
+  - `mobile/src/components/auth/AppleSignInButton.tsx`
+  - `mobile/src/components/auth/__tests__/AppleSignInButton.test.tsx`
+  - `mobile/src/screens/auth/LoginScreen.tsx`
+  - `mobile/src/screens/auth/RegisterScreen.tsx`
+  - `mobile/src/screens/auth/__tests__/LoginScreen.test.tsx`
+  - `mobile/src/screens/auth/__tests__/RegisterScreen.test.tsx`
+- **Depends on:** Task 6
+- **Commit:** `feat(mobile): add AppleSignInButton and wire into LoginScreen + RegisterScreen`
+- **Stack:** mobile
+
+### Task 8: Privacy policy update
+- **Files:**
+  - `web/src/app/[locale]/privacy/page.tsx`
+- **Depends on:** _none_
+- **Commit:** `docs(web): add Sign in with Apple data-handling section to privacy policy`
+- **Stack:** web
+
+---
+
+## Dependencies
+
+**Blocked by:**
+- Apple Developer Console setup (before on-device verification): Sign in with Apple capability enabled on `net.learnimo.app`, `.p8` key generated, Team ID + Key ID added to Railway env vars. Implementation and unit tests can proceed without this; on-device smoke test requires it.
+
+**Blocks:**
+- App Store resubmission (along with account-deletion, support page, and photo string fixes from the remediation plan)
+
+**External:**
+- `expo-apple-authentication` npm package (install with `--legacy-peer-deps`)
+- Apple JWK endpoint: `https://appleid.apple.com/auth/keys`
+- Sign in with Apple capability on App ID `net.learnimo.app` (Apple Developer Console)
+
+---
+
+## Post-Implementation Notes
+
+> _This section is filled AFTER implementation._
+
+### Commits
+_pending_
+
+### Architectural Decisions
+_pending_
+
+### Deviations from Spec
+_pending_
+
+### Lessons Learned
+_pending_

--- a/docs/specs/features/sign-in-with-apple.md
+++ b/docs/specs/features/sign-in-with-apple.md
@@ -1,6 +1,6 @@
 # Sign in with Apple
 
-> **Status:** Approved
+> **Status:** In Progress
 > **Created:** 2026-04-17
 > **Reviewed:** 2026-04-17
 > **Implemented:** _pending_

--- a/docs/specs/features/sign-in-with-apple.md
+++ b/docs/specs/features/sign-in-with-apple.md
@@ -2,6 +2,7 @@
 
 > **Status:** Approved
 > **Created:** 2026-04-17
+> **Reviewed:** 2026-04-17
 > **Implemented:** _pending_
 
 ---
@@ -34,7 +35,7 @@ This spec covers the full implementation: backend identity-token verification, n
 - [ ] **FR7** *(Must Have)* — If the provided email already belongs to a `local` or `google` account, respond 409 Conflict with a user-readable message.
 - [ ] **FR8** *(Must Have)* — On iOS, the `AppleSignInButton` is shown above the Google Sign-In button on both `LoginScreen` and `RegisterScreen`, using Apple's mandatory native `AppleAuthenticationButton` component.
 - [ ] **FR9** *(Must Have)* — On Android (and any non-iOS platform), the `AppleSignInButton` renders `null` — no button, no divider, no error.
-- [ ] **FR10** *(Must Have)* — `ChooseHandleScreen` handles Apple signup completion (passing `appleSub` and `email` from the temp token) alongside the existing Google path — no screen UI changes required.
+- [ ] **FR10** *(Must Have)* — `ChooseHandleScreen` handles Apple signup completion alongside the existing Google path with no UI changes. `AuthStackParamList` for `ChooseHandle` gains a `provider: 'google' | 'apple'` param; both `useGoogleAuth` and `useAppleAuth` pass it on navigation; `ChooseHandleScreen` uses it to call either `completeGoogleSignupApi` or `completeAppleSignupApi`.
 - [ ] **FR11** *(Must Have)* — i18n keys for Apple sign-in labels in both `en.ts` and `pt-BR.ts`.
 - [ ] **FR12** *(Should Have)* — The privacy policy page (`web/src/app/[locale]/privacy/page.tsx`) gains a paragraph describing what data Sign in with Apple shares with learnimo and how it is used.
 
@@ -65,7 +66,7 @@ This spec covers the full implementation: backend identity-token verification, n
 - `User` entity — add `apple_sub` field.
 - `UserRepository` — add `findByAppleSub(String)` and `existsByAppleSub(String)`.
 - Mobile `auth.ts` — add `appleLoginApi` and `completeAppleSignupApi` mirroring the Google pair.
-- Mobile `AuthStack.tsx` / `ChooseHandleScreen.tsx` — the temp token flow already handles Google; Apple uses identical params (`tempToken`, `email`) — no screen changes needed.
+- Mobile `AuthStack.tsx` / `ChooseHandleScreen.tsx` — `AuthStackParamList['ChooseHandle']` gains `provider: 'google' | 'apple'`. Both `useGoogleAuth` and `useAppleAuth` pass this param when navigating to `ChooseHandleScreen`. The screen reads `route.params.provider` and calls `completeGoogleSignupApi` or `completeAppleSignupApi` accordingly. No UI changes — the param is invisible to the user.
 
 **Apple Developer Console prerequisites (user-driven, before on-device verification):**
 - Sign in with Apple capability enabled on App ID `net.learnimo.app`.
@@ -188,7 +189,7 @@ This spec covers the full implementation: backend identity-token verification, n
 
 ### Screen: ChooseHandleScreen (no changes)
 
-**Purpose:** Unchanged — already accepts `{ tempToken, email }` params from Google. Apple uses the same params; no screen modification needed.
+**Purpose:** Accepts `{ tempToken, email, provider }` params. `provider: 'google' | 'apple'` is new — added to `AuthStackParamList['ChooseHandle']`. The screen uses it to route the completion call: `provider === 'apple'` → `completeAppleSignupApi`; otherwise → `completeGoogleSignupApi`. No UI change — the routing is invisible to the user.
 
 ---
 
@@ -252,6 +253,7 @@ userRepository.findByAppleSub(userInfo.sub())
 - `AppleSignInButton.test.tsx` — renders on iOS, returns null on Android.
 - `LoginScreen.test.tsx` — Apple button present on iOS, absent on Android.
 - `RegisterScreen.test.tsx` — same.
+- `ChooseHandleScreen.test.tsx` — `provider='apple'` calls `completeAppleSignupApi`; `provider='google'` calls `completeGoogleSignupApi`.
 
 ### File Changes
 
@@ -284,12 +286,15 @@ userRepository.findByAppleSub(userInfo.sub())
 - `mobile/package.json`
 - `mobile/app.json`
 - `mobile/src/lib/auth.ts`
+- `mobile/src/navigation/AuthStack.tsx`
 - `mobile/src/screens/auth/LoginScreen.tsx`
 - `mobile/src/screens/auth/RegisterScreen.tsx`
+- `mobile/src/screens/auth/ChooseHandleScreen.tsx`
 - `mobile/src/i18n/locales/en.ts`
 - `mobile/src/i18n/locales/pt-BR.ts`
 - `mobile/src/screens/auth/__tests__/LoginScreen.test.tsx`
 - `mobile/src/screens/auth/__tests__/RegisterScreen.test.tsx`
+- `mobile/src/screens/auth/__tests__/ChooseHandleScreen.test.tsx`
 
 **Modified (web):**
 - `web/src/app/[locale]/privacy/page.tsx`
@@ -368,16 +373,19 @@ CREATE UNIQUE INDEX users_apple_sub_unique
 - **Commit:** `feat(mobile): add appleLoginApi, useAppleAuth hook, and i18n keys`
 - **Stack:** mobile
 
-### Task 7: Mobile — AppleSignInButton + LoginScreen + RegisterScreen wiring + tests
+### Task 7: Mobile — AppleSignInButton + LoginScreen + RegisterScreen + ChooseHandleScreen wiring + tests
 - **Files:**
+  - `mobile/src/navigation/AuthStack.tsx`
   - `mobile/src/components/auth/AppleSignInButton.tsx`
   - `mobile/src/components/auth/__tests__/AppleSignInButton.test.tsx`
   - `mobile/src/screens/auth/LoginScreen.tsx`
   - `mobile/src/screens/auth/RegisterScreen.tsx`
+  - `mobile/src/screens/auth/ChooseHandleScreen.tsx`
   - `mobile/src/screens/auth/__tests__/LoginScreen.test.tsx`
   - `mobile/src/screens/auth/__tests__/RegisterScreen.test.tsx`
+  - `mobile/src/screens/auth/__tests__/ChooseHandleScreen.test.tsx`
 - **Depends on:** Task 6
-- **Commit:** `feat(mobile): add AppleSignInButton and wire into LoginScreen + RegisterScreen`
+- **Commit:** `feat(mobile): add AppleSignInButton, wire auth screens, add provider routing in ChooseHandleScreen`
 - **Stack:** mobile
 
 ### Task 8: Privacy policy update

--- a/docs/specs/features/sign-in-with-apple.md
+++ b/docs/specs/features/sign-in-with-apple.md
@@ -1,9 +1,9 @@
 # Sign in with Apple
 
-> **Status:** In Progress
+> **Status:** Implemented
 > **Created:** 2026-04-17
 > **Reviewed:** 2026-04-17
-> **Implemented:** _pending_
+> **Implemented:** 2026-04-18
 
 ---
 
@@ -417,13 +417,25 @@ CREATE UNIQUE INDEX users_apple_sub_unique
 > _This section is filled AFTER implementation._
 
 ### Commits
-_pending_
+- `0153320` feat(backend): add apple_sub column to users (V23 migration)
+- `8194f99` feat(backend): add Apple identity token verifier with JWK cache
+- `2bf56d7` feat(backend): add appleLogin and completeAppleSignup to AuthService
+- `f012678` feat(backend): add POST /auth/mobile/apple and /apple/complete endpoints
+- `d2f7f1b` feat(mobile): install expo-apple-authentication and register plugin
+- `d87c583` feat(mobile): add appleLoginApi, useAppleAuth hook, and i18n keys
+- `5d63d08` feat(mobile): add AppleSignInButton, wire auth screens, add provider routing in ChooseHandleScreen
+- `079cc43` docs(web): add Sign in with Apple data-handling section to privacy policy
 
 ### Architectural Decisions
-_pending_
+- **No new library dependencies on the backend.** Used `java.security` (`KeyFactory`, `RSAPublicKeySpec`) + JJWT 0.12.6 (already present) for RS256 token verification. Avoids version conflicts and keeps the dependency graph clean.
+- **Separate `generateAppleTempToken` / `parseAppleTempToken` in JwtService** rather than reusing the Google temp-token methods. Apple tokens use a different claim key (`appleSub` vs `googleSub`) and `type=apple_signup` marker, which makes them non-interchangeable at the type level and prevents confusion in the service layer.
+- **Partial unique index for `apple_sub`** (WHERE apple_sub IS NOT NULL) instead of a plain UNIQUE constraint. This allows multiple NULL values (users not yet linked to Apple) while enforcing uniqueness for non-null values. Standard Postgres pattern.
+- **`AppleSignInButton` returns `null` on non-iOS rather than hiding via style.** This is the correct approach per Apple's HIG — no invisible placeholder, no layout gap.
 
 ### Deviations from Spec
-_pending_
+- **`expo-apple-authentication` version pinned to `~55.0.0`** (not `~2.3.4` as initially drafted). The `2.x` semver range doesn't exist in the published package; SDK 53 requires the `55.x` range. Corrected during Task 6 implementation.
+- **`AppleLoginResponse` implemented as a record with factory methods** (`existingUser(tokens)`, `newUser(tempToken, email)`) rather than a plain class. Matches the existing `GoogleLoginResponse` pattern and reduces boilerplate.
 
 ### Lessons Learned
-_pending_
+- Apple identity tokens are standard JWTs signed with RS256 — the same JJWT parser used for our own tokens handles them cleanly once you have the RSAPublicKey from the JWK set. No Apple-specific SDK needed on the backend.
+- `expo-apple-authentication` semver follows Expo SDK major version (55.x for SDK 53), not its own semver progression. Always check Expo's package registry for the correct version range when adding new Expo packages.

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "learnimo",
     "slug": "learnimo",
-    "version": "1.0.21",
+    "version": "1.0.22",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -46,6 +46,7 @@
       "net.learnimo.app"
     ],
     "plugins": [
+      "expo-apple-authentication",
       "expo-secure-store",
       "expo-localization",
       [

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -19,6 +19,7 @@
         "@react-navigation/native-stack": "^6.11.0",
         "date-fns": "^4.1.0",
         "expo": "~53.0.0",
+        "expo-apple-authentication": "~55.0.0",
         "expo-auth-session": "~6.2.1",
         "expo-constants": "~17.1.8",
         "expo-crypto": "~14.1.5",
@@ -9505,6 +9506,16 @@
         "react-native-webview": {
           "optional": true
         }
+      }
+    },
+    "node_modules/expo-apple-authentication": {
+      "version": "55.0.13",
+      "resolved": "https://registry.npmjs.org/expo-apple-authentication/-/expo-apple-authentication-55.0.13.tgz",
+      "integrity": "sha512-Qvh3DmhXqhtWOe7BC9e7UVApR3XS1qE7+68tVLqb3KI/sET7QV9KT5JgOJogWmmCJVxA/kaot0M136yvW1pdWA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react-native": "*"
       }
     },
     "node_modules/expo-application": {

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -25,7 +25,7 @@
     "@react-navigation/native-stack": "^6.11.0",
     "date-fns": "^4.1.0",
     "expo": "~53.0.0",
-    "expo-apple-authentication": "~2.3.4",
+    "expo-apple-authentication": "~55.0.0",
     "expo-auth-session": "~6.2.1",
     "expo-constants": "~17.1.8",
     "expo-crypto": "~14.1.5",

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -25,6 +25,7 @@
     "@react-navigation/native-stack": "^6.11.0",
     "date-fns": "^4.1.0",
     "expo": "~53.0.0",
+    "expo-apple-authentication": "~2.3.4",
     "expo-auth-session": "~6.2.1",
     "expo-constants": "~17.1.8",
     "expo-crypto": "~14.1.5",

--- a/mobile/src/components/auth/AppleSignInButton.tsx
+++ b/mobile/src/components/auth/AppleSignInButton.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { Platform, StyleSheet } from 'react-native';
+import * as AppleAuthentication from 'expo-apple-authentication';
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+interface AppleSignInButtonProps {
+  onPress: () => Promise<void>;
+  loading?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function AppleSignInButton({
+  onPress,
+  loading = false,
+}: AppleSignInButtonProps): React.ReactElement | null {
+  // NFR3: Apple Sign In button is only available on iOS
+  if (Platform.OS !== 'ios') return null;
+
+  const styles = StyleSheet.create({
+    button: {
+      height: 44,
+      marginTop: 16,
+    },
+  });
+
+  return (
+    <AppleAuthentication.AppleAuthenticationButton
+      buttonType={AppleAuthentication.AppleAuthenticationButtonType.SIGN_IN}
+      buttonStyle={AppleAuthentication.AppleAuthenticationButtonStyle.BLACK}
+      cornerRadius={5}
+      style={styles.button}
+      onPress={loading ? undefined : onPress}
+    />
+  );
+}

--- a/mobile/src/components/auth/__tests__/AppleSignInButton.test.tsx
+++ b/mobile/src/components/auth/__tests__/AppleSignInButton.test.tsx
@@ -1,0 +1,123 @@
+/**
+ * AppleSignInButton component tests.
+ * Runs in the 'components' jest project (node environment).
+ * Calls component as a plain function — no RTL render needed.
+ */
+import React from 'react';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+jest.mock('expo-apple-authentication', () => ({
+  AppleAuthenticationButton: 'AppleAuthenticationButton',
+  AppleAuthenticationButtonType: { SIGN_IN: 0 },
+  AppleAuthenticationButtonStyle: { BLACK: 0 },
+  AppleAuthenticationScope: { FULL_NAME: 0, EMAIL: 1 },
+  AppleAuthenticationError: { CANCELED: 'ERR_REQUEST_CANCELED' },
+}));
+
+jest.mock('react-native', () => ({
+  Platform: { OS: 'ios' },
+  StyleSheet: { create: (s: any) => s },
+}));
+
+// ---------------------------------------------------------------------------
+// Imports (after mocks)
+// ---------------------------------------------------------------------------
+
+import { AppleSignInButton } from '../AppleSignInButton';
+
+// ---------------------------------------------------------------------------
+// Tree traversal helpers
+// ---------------------------------------------------------------------------
+
+function findAllByType(element: any, type: string): any[] {
+  const results: any[] = [];
+  function walk(el: any) {
+    if (!el) return;
+    if (Array.isArray(el)) { el.forEach(walk); return; }
+    if (typeof el !== 'object') return;
+    if (el.type === type || (el.type as any)?.name === type) results.push(el);
+    [el.props?.children].flat().forEach(walk);
+  }
+  walk(element);
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('AppleSignInButton', () => {
+  describe('on iOS', () => {
+    beforeEach(() => {
+      // Ensure Platform.OS is 'ios' (default from mock)
+      require('react-native').Platform.OS = 'ios';
+    });
+
+    it('renders the AppleAuthenticationButton on iOS', () => {
+      const result = AppleSignInButton({ onPress: jest.fn() });
+      expect(result).not.toBeNull();
+      const buttons = findAllByType(result, 'AppleAuthenticationButton');
+      expect(buttons).toHaveLength(1);
+    });
+
+    it('uses SIGN_IN button type', () => {
+      const result = AppleSignInButton({ onPress: jest.fn() });
+      const buttons = findAllByType(result, 'AppleAuthenticationButton');
+      expect(buttons[0].props.buttonType).toBe(0); // AppleAuthenticationButtonType.SIGN_IN
+    });
+
+    it('uses BLACK button style (NFR3: App Store compliant)', () => {
+      const result = AppleSignInButton({ onPress: jest.fn() });
+      const buttons = findAllByType(result, 'AppleAuthenticationButton');
+      expect(buttons[0].props.buttonStyle).toBe(0); // AppleAuthenticationButtonStyle.BLACK
+    });
+
+    it('passes onPress to the button when not loading', () => {
+      const onPress = jest.fn();
+      const result = AppleSignInButton({ onPress });
+      const buttons = findAllByType(result, 'AppleAuthenticationButton');
+      expect(buttons[0].props.onPress).toBe(onPress);
+    });
+
+    it('sets onPress to undefined when loading=true (prevent double-tap)', () => {
+      const onPress = jest.fn();
+      const result = AppleSignInButton({ onPress, loading: true });
+      const buttons = findAllByType(result, 'AppleAuthenticationButton');
+      expect(buttons[0].props.onPress).toBeUndefined();
+    });
+
+    it('loading defaults to false', () => {
+      const onPress = jest.fn();
+      const result = AppleSignInButton({ onPress });
+      const buttons = findAllByType(result, 'AppleAuthenticationButton');
+      // When loading=false, onPress should be passed through
+      expect(buttons[0].props.onPress).toBe(onPress);
+    });
+  });
+
+  describe('on Android', () => {
+    let originalPlatform: any;
+
+    beforeEach(() => {
+      originalPlatform = require('react-native').Platform.OS;
+      require('react-native').Platform.OS = 'android';
+    });
+
+    afterEach(() => {
+      require('react-native').Platform.OS = originalPlatform;
+    });
+
+    it('returns null on Android (Apple Sign In not available)', () => {
+      const result = AppleSignInButton({ onPress: jest.fn() });
+      expect(result).toBeNull();
+    });
+
+    it('renders nothing on Android — no AppleAuthenticationButton', () => {
+      const result = AppleSignInButton({ onPress: jest.fn() });
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/mobile/src/hooks/__tests__/useAppleAuth.test.ts
+++ b/mobile/src/hooks/__tests__/useAppleAuth.test.ts
@@ -1,0 +1,231 @@
+/**
+ * useAppleAuth — unit tests (lib jest project, node env).
+ *
+ * Strategy: Call the hook as a plain function (no renderHook) by mocking all
+ * React hooks at module scope. The AppleAuthentication.signInAsync call is
+ * tested by controlling the resolved/rejected values of the mock.
+ *
+ * Jest hoisting rule: jest.mock() factories cannot reference out-of-scope
+ * variables. Module-scope variables with a 'mock' prefix are allowed.
+ */
+
+// ---------------------------------------------------------------------------
+// Module-scope mocks for useState — 'mock' prefix satisfies Jest hoisting rule
+// ---------------------------------------------------------------------------
+let mockStateCallCount = 0;
+const mockSetLoading = jest.fn();
+const mockUseState = jest.fn((init: unknown) => {
+  mockStateCallCount++;
+  return [init, mockSetLoading];
+});
+
+jest.mock('react', () => ({
+  ...jest.requireActual('react'),
+  useState: (...args: unknown[]) => mockUseState(...args),
+}));
+
+// ---------------------------------------------------------------------------
+// expo-apple-authentication mock
+// ---------------------------------------------------------------------------
+const mockSignInAsync = jest.fn();
+
+jest.mock('expo-apple-authentication', () => ({
+  __esModule: true,
+  default: {
+    signInAsync: (...args: unknown[]) => mockSignInAsync(...args),
+    AppleAuthenticationScope: { FULL_NAME: 0, EMAIL: 1 },
+    AppleAuthenticationError: { CANCELED: 'ERR_REQUEST_CANCELED' },
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// @/lib/auth mock
+// ---------------------------------------------------------------------------
+const mockAppleLoginApi = jest.fn();
+jest.mock('@/lib/auth', () => ({
+  appleLoginApi: (...args: unknown[]) => mockAppleLoginApi(...args),
+}));
+
+// ---------------------------------------------------------------------------
+// Imports (after mocks)
+// ---------------------------------------------------------------------------
+import { useAppleAuth } from '../useAppleAuth';
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  mockStateCallCount = 0;
+  mockUseState.mockClear();
+  mockSetLoading.mockClear();
+  mockSignInAsync.mockClear();
+  mockAppleLoginApi.mockClear();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useAppleAuth', () => {
+  const onSuccess = jest.fn();
+  const onError = jest.fn();
+
+  beforeEach(() => {
+    onSuccess.mockClear();
+    onError.mockClear();
+  });
+
+  describe('cancel — silent no-op', () => {
+    it('does NOT call onError when user cancels (CANCELED error code)', async () => {
+      const cancelError = Object.assign(new Error('User cancelled'), {
+        code: 'ERR_REQUEST_CANCELED',
+      });
+      mockSignInAsync.mockRejectedValue(cancelError);
+
+      const result = useAppleAuth(onSuccess, onError);
+      await result.handlePress();
+
+      expect(onError).not.toHaveBeenCalled();
+      expect(onSuccess).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('auth error — onError called', () => {
+    it('calls onError with appleFailed key when signInAsync throws a non-cancel error', async () => {
+      mockSignInAsync.mockRejectedValue(new Error('Unknown auth error'));
+
+      const result = useAppleAuth(onSuccess, onError);
+      await result.handlePress();
+
+      expect(onError).toHaveBeenCalledWith('auth.errors.appleFailed');
+      expect(onSuccess).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('null identityToken — onError called', () => {
+    it('calls onError with appleFailed key when identityToken is null', async () => {
+      mockSignInAsync.mockResolvedValue({
+        identityToken: null,
+        user: 'apple-user-id',
+        email: 'user@privaterelay.appleid.com',
+        fullName: { givenName: 'John', familyName: 'Doe' },
+      });
+
+      const result = useAppleAuth(onSuccess, onError);
+      await result.handlePress();
+
+      expect(onError).toHaveBeenCalledWith('auth.errors.appleFailed');
+      expect(onSuccess).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('new user (requiresHandle=true)', () => {
+    it('calls onSuccess with type=new and provider=apple when requiresHandle is true', async () => {
+      mockSignInAsync.mockResolvedValue({
+        identityToken: 'test-identity-token',
+        user: 'apple-user-id',
+        email: 'newuser@privaterelay.appleid.com',
+        fullName: { givenName: 'Jane', familyName: 'Doe' },
+      });
+
+      mockAppleLoginApi.mockResolvedValue({
+        requiresHandle: true,
+        tempToken: 'tmp-apple-abc',
+        email: 'newuser@privaterelay.appleid.com',
+        handle: null,
+        userId: null,
+        accessToken: null,
+        refreshToken: null,
+      });
+
+      const result = useAppleAuth(onSuccess, onError);
+      await result.handlePress();
+
+      expect(mockAppleLoginApi).toHaveBeenCalledWith('test-identity-token');
+      expect(onSuccess).toHaveBeenCalledWith({
+        type: 'new',
+        tempToken: 'tmp-apple-abc',
+        email: 'newuser@privaterelay.appleid.com',
+      });
+      expect(onError).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('existing user (requiresHandle=false)', () => {
+    it('calls onSuccess with type=existing when requiresHandle is false', async () => {
+      mockSignInAsync.mockResolvedValue({
+        identityToken: 'existing-user-token',
+        user: 'apple-user-id',
+        email: null,
+        fullName: null,
+      });
+
+      mockAppleLoginApi.mockResolvedValue({
+        requiresHandle: false,
+        tempToken: null,
+        handle: 'applice',
+        userId: 'user-456',
+        email: 'alice@privaterelay.appleid.com',
+        accessToken: 'tok-access',
+        refreshToken: 'tok-refresh',
+      });
+
+      const result = useAppleAuth(onSuccess, onError);
+      await result.handlePress();
+
+      expect(mockAppleLoginApi).toHaveBeenCalledWith('existing-user-token');
+      expect(onSuccess).toHaveBeenCalledWith({
+        type: 'existing',
+        user: { handle: 'applice', userId: 'user-456', email: 'alice@privaterelay.appleid.com' },
+      });
+      expect(onError).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('backend API error', () => {
+    it('calls onError with appleFailed key when appleLoginApi rejects', async () => {
+      mockSignInAsync.mockResolvedValue({
+        identityToken: 'valid-token',
+        user: 'apple-user-id',
+        email: null,
+        fullName: null,
+      });
+
+      mockAppleLoginApi.mockRejectedValue(new Error('Network error'));
+
+      const result = useAppleAuth(onSuccess, onError);
+      await result.handlePress();
+
+      expect(onError).toHaveBeenCalledWith('auth.errors.appleFailed');
+      expect(onSuccess).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('loading state', () => {
+    it('sets loading=true at start and loading=false after completion', async () => {
+      mockSignInAsync.mockResolvedValue({
+        identityToken: 'valid-token',
+        user: 'apple-user-id',
+        email: null,
+        fullName: null,
+      });
+
+      mockAppleLoginApi.mockResolvedValue({
+        requiresHandle: false,
+        tempToken: null,
+        handle: 'bob',
+        userId: 'user-789',
+        email: 'bob@privaterelay.appleid.com',
+        accessToken: 'tok-access',
+        refreshToken: 'tok-refresh',
+      });
+
+      const result = useAppleAuth(onSuccess, onError);
+      await result.handlePress();
+
+      expect(mockSetLoading).toHaveBeenCalledWith(true);
+      expect(mockSetLoading).toHaveBeenCalledWith(false);
+    });
+  });
+});

--- a/mobile/src/hooks/useAppleAuth.ts
+++ b/mobile/src/hooks/useAppleAuth.ts
@@ -1,0 +1,88 @@
+import { useState } from 'react';
+import AppleAuthentication from 'expo-apple-authentication';
+import { appleLoginApi } from '@/lib/auth';
+import type { AuthResponse } from '@/lib/auth';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type AppleAuthSuccess =
+  | { type: 'existing'; user: AuthResponse }
+  | { type: 'new'; tempToken: string; email: string };
+
+export interface UseAppleAuthReturn {
+  loading: boolean;
+  handlePress: () => Promise<void>;
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export function useAppleAuth(
+  onSuccess: (result: AppleAuthSuccess) => void,
+  onError: (message: string) => void
+): UseAppleAuthReturn {
+  const [loading, setLoading] = useState(false);
+
+  const handlePress = async (): Promise<void> => {
+    setLoading(true);
+    try {
+      const credential = await AppleAuthentication.signInAsync({
+        requestedScopes: [
+          AppleAuthentication.AppleAuthenticationScope.FULL_NAME,
+          AppleAuthentication.AppleAuthenticationScope.EMAIL,
+        ],
+      });
+
+      const { identityToken } = credential;
+
+      if (!identityToken) {
+        setLoading(false);
+        onError('auth.errors.appleFailed');
+        return;
+      }
+
+      try {
+        const result = await appleLoginApi(identityToken);
+
+        if (result.requiresHandle) {
+          // New user — navigate to ChooseHandle
+          onSuccess({
+            type: 'new',
+            tempToken: result.tempToken!,
+            email: result.email!,
+          });
+        } else {
+          // Existing user — tokens already stored by appleLoginApi
+          onSuccess({
+            type: 'existing',
+            user: {
+              handle: result.handle!,
+              userId: result.userId!,
+              email: result.email!,
+            },
+          });
+        }
+      } catch {
+        // Backend API error
+        onError('auth.errors.appleFailed');
+      } finally {
+        setLoading(false);
+      }
+    } catch (err: unknown) {
+      setLoading(false);
+      // Silent no-op on user cancel
+      if (
+        err instanceof Error &&
+        (err as { code?: string }).code === AppleAuthentication.AppleAuthenticationError.CANCELED
+      ) {
+        return;
+      }
+      onError('auth.errors.appleFailed');
+    }
+  };
+
+  return { loading, handlePress };
+}

--- a/mobile/src/i18n/locales/en.ts
+++ b/mobile/src/i18n/locales/en.ts
@@ -13,6 +13,7 @@ export default {
       signUp: 'Sign up',
       orContinueWith: 'Or continue with',
       googleButton: 'Continue with Google',
+      appleButton: 'Sign in with Apple',
     },
     register: {
       title: 'Create account',
@@ -67,6 +68,7 @@ export default {
       loginFailed: 'Invalid email or password',
       registerFailed: 'Could not create account. Please try again.',
       googleFailed: 'Google sign-in failed. Please try again.',
+      appleFailed: 'Sign in with Apple failed. Try again.',
     },
   },
 

--- a/mobile/src/i18n/locales/pt-BR.ts
+++ b/mobile/src/i18n/locales/pt-BR.ts
@@ -12,6 +12,7 @@ export default {
       signUp: 'Cadastre-se',
       orContinueWith: 'Ou continue com',
       googleButton: 'Continuar com Google',
+      appleButton: 'Entrar com Apple',
     },
     register: {
       title: 'Criar conta',
@@ -66,6 +67,7 @@ export default {
       loginFailed: 'E-mail ou senha inválidos',
       registerFailed: 'Não foi possível criar a conta. Tente novamente.',
       googleFailed: 'Falha no login com Google. Tente novamente.',
+      appleFailed: 'Falha ao entrar com Apple. Tente novamente.',
     },
   },
 

--- a/mobile/src/lib/auth.ts
+++ b/mobile/src/lib/auth.ts
@@ -70,6 +70,24 @@ export interface CompleteGoogleSignupPayload {
   displayName: string;
 }
 
+export interface AppleLoginResponse {
+  requiresHandle: boolean;
+  tempToken: string | null;
+  handle: string | null;
+  userId: string | null;
+  email: string | null;
+  /** Present when requiresHandle=false — store in SecureStore. */
+  accessToken: string | null;
+  /** Present when requiresHandle=false — store in SecureStore. */
+  refreshToken: string | null;
+}
+
+export interface CompleteAppleSignupPayload {
+  tempToken: string;
+  handle: string;
+  displayName: string;
+}
+
 // ---------------------------------------------------------------------------
 // Internal helper
 // ---------------------------------------------------------------------------
@@ -141,6 +159,31 @@ export async function completeGoogleSignupApi(
   payload: CompleteGoogleSignupPayload
 ): Promise<AuthResponse> {
   const data = await apiPublicFetch<BackendAuthResponse>('/auth/mobile/google/complete', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+  return storeTokensAndReturn(data);
+}
+
+export async function appleLoginApi(identityToken: string): Promise<AppleLoginResponse> {
+  const data = await apiPublicFetch<AppleLoginResponse>('/auth/mobile/apple', {
+    method: 'POST',
+    body: JSON.stringify({ identityToken }),
+  });
+
+  // Existing user path — store tokens immediately
+  if (!data.requiresHandle && data.accessToken && data.refreshToken) {
+    await tokenStore.setAccessToken(data.accessToken);
+    await tokenStore.setRefreshToken(data.refreshToken);
+  }
+
+  return data;
+}
+
+export async function completeAppleSignupApi(
+  payload: CompleteAppleSignupPayload
+): Promise<AuthResponse> {
+  const data = await apiPublicFetch<BackendAuthResponse>('/auth/mobile/apple/complete', {
     method: 'POST',
     body: JSON.stringify(payload),
   });

--- a/mobile/src/navigation/AuthStack.tsx
+++ b/mobile/src/navigation/AuthStack.tsx
@@ -6,7 +6,7 @@ export type AuthStackParamList = {
   Login: undefined;
   Register: undefined;
   ForgotPassword: undefined;
-  ChooseHandle: { tempToken: string; email: string };
+  ChooseHandle: { tempToken: string; email: string; provider?: 'google' | 'apple' };
 };
 
 const Stack = createNativeStackNavigator<AuthStackParamList>();

--- a/mobile/src/screens/auth/ChooseHandleScreen.tsx
+++ b/mobile/src/screens/auth/ChooseHandleScreen.tsx
@@ -7,7 +7,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { useTheme } from '@/contexts/ThemeContext';
 import { useI18n } from '@/contexts/I18nContext';
 import { useAuth } from '@/contexts/AuthContext';
-import { completeGoogleSignupApi } from '@/lib/auth';
+import { completeGoogleSignupApi, completeAppleSignupApi } from '@/lib/auth';
 import { ApiRequestError } from '@/lib/api';
 import { chooseHandleSchema, ChooseHandleFormData } from '@/lib/validations';
 import type { AuthStackParamList } from '@/navigation/AuthStack';
@@ -23,7 +23,7 @@ export function ChooseHandleScreen() {
   const { t } = useI18n();
   const { setUser } = useAuth();
   const route = useRoute<RouteProps>();
-  const { tempToken } = route.params;
+  const { tempToken, provider = 'google' } = route.params;
   const [serverError, setServerError] = useState<string | null>(null);
 
   const {
@@ -38,7 +38,9 @@ export function ChooseHandleScreen() {
   async function onSubmit(data: ChooseHandleFormData) {
     setServerError(null);
     try {
-      const user = await completeGoogleSignupApi({
+      const completeSignupApi =
+        provider === 'apple' ? completeAppleSignupApi : completeGoogleSignupApi;
+      const user = await completeSignupApi({
         tempToken,
         handle: data.handle,
         displayName: data.displayName,

--- a/mobile/src/screens/auth/LoginScreen.tsx
+++ b/mobile/src/screens/auth/LoginScreen.tsx
@@ -1,27 +1,28 @@
-import React, { useState } from 'react';
-import { KeyboardAvoidingView, Platform, ScrollView, View } from 'react-native';
+import { zodResolver } from '@hookform/resolvers/zod';
 import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import { useForm, Controller } from 'react-hook-form';
-import { zodResolver } from '@hookform/resolvers/zod';
+import React, { useState } from 'react';
+import { Controller,useForm } from 'react-hook-form';
+import { KeyboardAvoidingView, Platform, ScrollView, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { useTheme } from '@/contexts/ThemeContext';
-import { useI18n } from '@/contexts/I18nContext';
-import { useAuth } from '@/contexts/AuthContext';
-import { loginApi } from '@/lib/auth';
-import { ApiRequestError } from '@/lib/api';
-import { loginSchema, LoginFormData } from '@/lib/validations';
-import type { AuthStackParamList } from '@/navigation/AuthStack';
-import { Button } from '@/components/ui/Button';
-import { TextInput } from '@/components/ui/TextInput';
-import { Text } from '@/components/ui/Text';
-import { ErrorMessage } from '@/components/ui/ErrorMessage';
-import { GoogleSignInButton } from '@/components/auth/GoogleSignInButton';
+
 import { AppleSignInButton } from '@/components/auth/AppleSignInButton';
-import { useGoogleAuth } from '@/hooks/useGoogleAuth';
-import type { GoogleAuthSuccess } from '@/hooks/useGoogleAuth';
-import { useAppleAuth } from '@/hooks/useAppleAuth';
+import { GoogleSignInButton } from '@/components/auth/GoogleSignInButton';
+import { Button } from '@/components/ui/Button';
+import { ErrorMessage } from '@/components/ui/ErrorMessage';
+import { Text } from '@/components/ui/Text';
+import { TextInput } from '@/components/ui/TextInput';
+import { useAuth } from '@/contexts/AuthContext';
+import { useI18n } from '@/contexts/I18nContext';
+import { useTheme } from '@/contexts/ThemeContext';
 import type { AppleAuthSuccess } from '@/hooks/useAppleAuth';
+import { useAppleAuth } from '@/hooks/useAppleAuth';
+import type { GoogleAuthSuccess } from '@/hooks/useGoogleAuth';
+import { useGoogleAuth } from '@/hooks/useGoogleAuth';
+import { ApiRequestError } from '@/lib/api';
+import { loginApi } from '@/lib/auth';
+import { LoginFormData,loginSchema } from '@/lib/validations';
+import type { AuthStackParamList } from '@/navigation/AuthStack';
 
 type Nav = NativeStackNavigationProp<AuthStackParamList, 'Login'>;
 

--- a/mobile/src/screens/auth/LoginScreen.tsx
+++ b/mobile/src/screens/auth/LoginScreen.tsx
@@ -17,8 +17,11 @@ import { TextInput } from '@/components/ui/TextInput';
 import { Text } from '@/components/ui/Text';
 import { ErrorMessage } from '@/components/ui/ErrorMessage';
 import { GoogleSignInButton } from '@/components/auth/GoogleSignInButton';
+import { AppleSignInButton } from '@/components/auth/AppleSignInButton';
 import { useGoogleAuth } from '@/hooks/useGoogleAuth';
 import type { GoogleAuthSuccess } from '@/hooks/useGoogleAuth';
+import { useAppleAuth } from '@/hooks/useAppleAuth';
+import type { AppleAuthSuccess } from '@/hooks/useAppleAuth';
 
 type Nav = NativeStackNavigationProp<AuthStackParamList, 'Login'>;
 
@@ -33,14 +36,28 @@ export function LoginScreen() {
     if (result.type === 'existing') {
       setUser(result.user);
     } else {
-      nav.navigate('ChooseHandle', { tempToken: result.tempToken, email: result.email });
+      nav.navigate('ChooseHandle', { tempToken: result.tempToken, email: result.email, provider: 'google' });
     }
   };
-  const { loading: googleLoading, handlePress, disabled: googleDisabled } =
+  const { loading: googleLoading, handlePress: googleHandlePress, disabled: googleDisabled } =
     useGoogleAuth(handleGoogleSuccess, (msg) => setServerError(t(msg)));
   const handleGoogleSignIn = async () => {
     setServerError(null);
-    await handlePress();
+    await googleHandlePress();
+  };
+
+  const handleAppleSuccess = (result: AppleAuthSuccess) => {
+    if (result.type === 'existing') {
+      setUser(result.user);
+    } else {
+      nav.navigate('ChooseHandle', { tempToken: result.tempToken, email: result.email, provider: 'apple' });
+    }
+  };
+  const { loading: appleLoading, handlePress: appleHandlePress } =
+    useAppleAuth(handleAppleSuccess, (msg) => setServerError(t(msg)));
+  const handleAppleSignIn = async () => {
+    setServerError(null);
+    await appleHandlePress();
   };
 
   const {
@@ -133,6 +150,11 @@ export function LoginScreen() {
             label={t('auth.login.forgotPassword')}
             variant="ghost"
             onPress={() => nav.navigate('ForgotPassword')}
+          />
+
+          <AppleSignInButton
+            loading={appleLoading}
+            onPress={handleAppleSignIn}
           />
 
           <GoogleSignInButton

--- a/mobile/src/screens/auth/RegisterScreen.tsx
+++ b/mobile/src/screens/auth/RegisterScreen.tsx
@@ -17,8 +17,11 @@ import { TextInput } from '@/components/ui/TextInput';
 import { Text } from '@/components/ui/Text';
 import { ErrorMessage } from '@/components/ui/ErrorMessage';
 import { GoogleSignInButton } from '@/components/auth/GoogleSignInButton';
+import { AppleSignInButton } from '@/components/auth/AppleSignInButton';
 import { useGoogleAuth } from '@/hooks/useGoogleAuth';
 import type { GoogleAuthSuccess } from '@/hooks/useGoogleAuth';
+import { useAppleAuth } from '@/hooks/useAppleAuth';
+import type { AppleAuthSuccess } from '@/hooks/useAppleAuth';
 
 type Nav = NativeStackNavigationProp<AuthStackParamList, 'Register'>;
 
@@ -33,14 +36,28 @@ export function RegisterScreen() {
     if (result.type === 'existing') {
       setUser(result.user);
     } else {
-      nav.navigate('ChooseHandle', { tempToken: result.tempToken, email: result.email });
+      nav.navigate('ChooseHandle', { tempToken: result.tempToken, email: result.email, provider: 'google' });
     }
   };
-  const { loading: googleLoading, handlePress, disabled: googleDisabled } =
+  const { loading: googleLoading, handlePress: googleHandlePress, disabled: googleDisabled } =
     useGoogleAuth(handleGoogleSuccess, (msg) => setServerError(t(msg)));
   const handleGoogleSignIn = async () => {
     setServerError(null);
-    await handlePress();
+    await googleHandlePress();
+  };
+
+  const handleAppleSuccess = (result: AppleAuthSuccess) => {
+    if (result.type === 'existing') {
+      setUser(result.user);
+    } else {
+      nav.navigate('ChooseHandle', { tempToken: result.tempToken, email: result.email, provider: 'apple' });
+    }
+  };
+  const { loading: appleLoading, handlePress: appleHandlePress } =
+    useAppleAuth(handleAppleSuccess, (msg) => setServerError(t(msg)));
+  const handleAppleSignIn = async () => {
+    setServerError(null);
+    await appleHandlePress();
   };
 
   const {
@@ -181,6 +198,11 @@ export function RegisterScreen() {
             onPress={handleSubmit(onSubmit)}
             loading={isSubmitting}
             fullWidth
+          />
+
+          <AppleSignInButton
+            loading={appleLoading}
+            onPress={handleAppleSignIn}
           />
 
           <GoogleSignInButton

--- a/mobile/src/screens/auth/RegisterScreen.tsx
+++ b/mobile/src/screens/auth/RegisterScreen.tsx
@@ -1,27 +1,28 @@
-import React, { useState } from 'react';
-import { KeyboardAvoidingView, Platform, ScrollView, View } from 'react-native';
+import { zodResolver } from '@hookform/resolvers/zod';
 import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import { useForm, Controller } from 'react-hook-form';
-import { zodResolver } from '@hookform/resolvers/zod';
+import React, { useState } from 'react';
+import { Controller,useForm } from 'react-hook-form';
+import { KeyboardAvoidingView, Platform, ScrollView, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { useTheme } from '@/contexts/ThemeContext';
-import { useI18n } from '@/contexts/I18nContext';
-import { useAuth } from '@/contexts/AuthContext';
-import { registerApi } from '@/lib/auth';
-import { ApiRequestError } from '@/lib/api';
-import { registerSchema, RegisterFormData } from '@/lib/validations';
-import type { AuthStackParamList } from '@/navigation/AuthStack';
-import { Button } from '@/components/ui/Button';
-import { TextInput } from '@/components/ui/TextInput';
-import { Text } from '@/components/ui/Text';
-import { ErrorMessage } from '@/components/ui/ErrorMessage';
-import { GoogleSignInButton } from '@/components/auth/GoogleSignInButton';
+
 import { AppleSignInButton } from '@/components/auth/AppleSignInButton';
-import { useGoogleAuth } from '@/hooks/useGoogleAuth';
-import type { GoogleAuthSuccess } from '@/hooks/useGoogleAuth';
-import { useAppleAuth } from '@/hooks/useAppleAuth';
+import { GoogleSignInButton } from '@/components/auth/GoogleSignInButton';
+import { Button } from '@/components/ui/Button';
+import { ErrorMessage } from '@/components/ui/ErrorMessage';
+import { Text } from '@/components/ui/Text';
+import { TextInput } from '@/components/ui/TextInput';
+import { useAuth } from '@/contexts/AuthContext';
+import { useI18n } from '@/contexts/I18nContext';
+import { useTheme } from '@/contexts/ThemeContext';
 import type { AppleAuthSuccess } from '@/hooks/useAppleAuth';
+import { useAppleAuth } from '@/hooks/useAppleAuth';
+import type { GoogleAuthSuccess } from '@/hooks/useGoogleAuth';
+import { useGoogleAuth } from '@/hooks/useGoogleAuth';
+import { ApiRequestError } from '@/lib/api';
+import { registerApi } from '@/lib/auth';
+import { RegisterFormData,registerSchema } from '@/lib/validations';
+import type { AuthStackParamList } from '@/navigation/AuthStack';
 
 type Nav = NativeStackNavigationProp<AuthStackParamList, 'Register'>;
 

--- a/mobile/src/screens/auth/__tests__/ChooseHandleScreen.test.tsx
+++ b/mobile/src/screens/auth/__tests__/ChooseHandleScreen.test.tsx
@@ -27,16 +27,19 @@ jest.mock('@/contexts/AuthContext', () => ({
   useAuth: () => ({ setUser: mockSetUser }),
 }));
 
+let mockRouteParams: Record<string, unknown> = { tempToken: 'google-temp-token-abc' };
 jest.mock('@react-navigation/native', () => ({
   useNavigation: () => ({ navigate: jest.fn() }),
-  useRoute: () => ({ params: { tempToken: 'google-temp-token-abc' } }),
+  useRoute: () => ({ params: mockRouteParams }),
 }));
 
 jest.mock('@react-navigation/native-stack', () => ({}));
 
 const mockCompleteGoogleSignupApi = jest.fn();
+const mockCompleteAppleSignupApi = jest.fn();
 jest.mock('@/lib/auth', () => ({
   completeGoogleSignupApi: (...args: unknown[]) => mockCompleteGoogleSignupApi(...args),
+  completeAppleSignupApi: (...args: unknown[]) => mockCompleteAppleSignupApi(...args),
 }));
 
 jest.mock('@/lib/api', () => ({
@@ -95,6 +98,7 @@ import type { ReactEl } from './test-utils';
 describe('ChooseHandleScreen', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockRouteParams = { tempToken: 'google-temp-token-abc' };
     mockHandleSubmit.mockImplementation((onSubmit) =>
       jest.fn(() => onSubmit({ handle: 'johndoe', displayName: 'John Doe' }))
     );
@@ -185,5 +189,76 @@ describe('ChooseHandleScreen', () => {
     // ChooseHandle has only one button (submit) — no back/ghost button
     expect(buttons.length).toBe(1);
     expect(buttons[0].props.fullWidth).toBe(true);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Provider routing tests
+  // ---------------------------------------------------------------------------
+
+  it('calls completeGoogleSignupApi when provider is "google"', async () => {
+    mockRouteParams = { tempToken: 'google-temp-token-abc', provider: 'google' };
+    const user = { id: '3', email: 'google@example.com' };
+    mockCompleteGoogleSignupApi.mockResolvedValue(user);
+
+    const result = ChooseHandleScreen({} as never);
+    const buttons = findAllByType(result, 'Button');
+    const submitBtn = buttons.find((b) => b.props.fullWidth === true);
+
+    await (submitBtn?.props.onPress as () => Promise<void>)();
+
+    expect(mockCompleteGoogleSignupApi).toHaveBeenCalledWith({
+      tempToken: 'google-temp-token-abc',
+      handle: 'johndoe',
+      displayName: 'John Doe',
+    });
+    expect(mockCompleteAppleSignupApi).not.toHaveBeenCalled();
+  });
+
+  it('calls completeAppleSignupApi when provider is "apple"', async () => {
+    mockRouteParams = { tempToken: 'apple-temp-token-xyz', provider: 'apple' };
+    const user = { id: '4', email: 'apple@privaterelay.apple.com' };
+    mockCompleteAppleSignupApi.mockResolvedValue(user);
+
+    const result = ChooseHandleScreen({} as never);
+    const buttons = findAllByType(result, 'Button');
+    const submitBtn = buttons.find((b) => b.props.fullWidth === true);
+
+    await (submitBtn?.props.onPress as () => Promise<void>)();
+
+    expect(mockCompleteAppleSignupApi).toHaveBeenCalledWith({
+      tempToken: 'apple-temp-token-xyz',
+      handle: 'johndoe',
+      displayName: 'John Doe',
+    });
+    expect(mockCompleteGoogleSignupApi).not.toHaveBeenCalled();
+  });
+
+  it('defaults to completeGoogleSignupApi when provider is absent (backwards compat)', async () => {
+    mockRouteParams = { tempToken: 'google-temp-token-abc' };
+    const user = { id: '3', email: 'google@example.com' };
+    mockCompleteGoogleSignupApi.mockResolvedValue(user);
+
+    const result = ChooseHandleScreen({} as never);
+    const buttons = findAllByType(result, 'Button');
+    const submitBtn = buttons.find((b) => b.props.fullWidth === true);
+
+    await (submitBtn?.props.onPress as () => Promise<void>)();
+
+    expect(mockCompleteGoogleSignupApi).toHaveBeenCalled();
+    expect(mockCompleteAppleSignupApi).not.toHaveBeenCalled();
+  });
+
+  it('calls setUser after successful Apple signup completion', async () => {
+    mockRouteParams = { tempToken: 'apple-temp-token-xyz', provider: 'apple' };
+    const user = { id: '4', email: 'apple@privaterelay.apple.com' };
+    mockCompleteAppleSignupApi.mockResolvedValue(user);
+
+    const result = ChooseHandleScreen({} as never);
+    const buttons = findAllByType(result, 'Button');
+    const submitBtn = buttons.find((b) => b.props.fullWidth === true);
+
+    await (submitBtn?.props.onPress as () => Promise<void>)();
+
+    expect(mockSetUser).toHaveBeenCalledWith(user);
   });
 });

--- a/mobile/src/screens/auth/__tests__/LoginScreen.test.tsx
+++ b/mobile/src/screens/auth/__tests__/LoginScreen.test.tsx
@@ -98,6 +98,16 @@ jest.mock('@/components/auth/GoogleSignInButton', () => ({
   GoogleSignInButton: (props: Record<string, unknown>) => require('react').createElement('GoogleSignInButton', props),
 }));
 
+const mockAppleHandlePress = jest.fn();
+const mockUseAppleAuth = jest.fn(() => ({ loading: false, handlePress: mockAppleHandlePress }));
+jest.mock('@/hooks/useAppleAuth', () => ({
+  useAppleAuth: (...args: unknown[]) => mockUseAppleAuth(...args),
+}));
+
+jest.mock('@/components/auth/AppleSignInButton', () => ({
+  AppleSignInButton: (props: Record<string, unknown>) => require('react').createElement('AppleSignInButton', props),
+}));
+
 // ---------------------------------------------------------------------------
 // Import under test (after mocks)
 // ---------------------------------------------------------------------------
@@ -117,6 +127,7 @@ describe('LoginScreen', () => {
       jest.fn(() => onSubmit({ email: 'test@example.com', password: 'mock-p4ssword' }))
     );
     mockUseGoogleAuth.mockImplementation(() => ({ loading: false, handlePress: mockHandlePress, disabled: false }));
+    mockUseAppleAuth.mockImplementation(() => ({ loading: false, handlePress: mockAppleHandlePress }));
   });
 
   it('returns a valid React element', () => {
@@ -257,5 +268,37 @@ describe('LoginScreen', () => {
     const googleBtns = findAllByType(result, 'GoogleSignInButton');
     await (googleBtns[0].props.onPress as () => Promise<void>)();
     expect(mockHandlePress).toHaveBeenCalled();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Apple Sign-In tests
+  // ---------------------------------------------------------------------------
+
+  it('renders AppleSignInButton', () => {
+    const result = LoginScreen({} as never);
+    const appleBtns = findAllByType(result, 'AppleSignInButton');
+    expect(appleBtns.length).toBeGreaterThan(0);
+  });
+
+  it('passes loading=false to AppleSignInButton by default', () => {
+    mockUseAppleAuth.mockReturnValue({ loading: false, handlePress: mockAppleHandlePress });
+    const result = LoginScreen({} as never);
+    const appleBtns = findAllByType(result, 'AppleSignInButton');
+    expect(appleBtns[0].props.loading).toBe(false);
+  });
+
+  it('passes loading=true to AppleSignInButton when apple auth is loading', () => {
+    mockUseAppleAuth.mockReturnValue({ loading: true, handlePress: mockAppleHandlePress });
+    const result = LoginScreen({} as never);
+    const appleBtns = findAllByType(result, 'AppleSignInButton');
+    expect(appleBtns[0].props.loading).toBe(true);
+  });
+
+  it('tapping AppleSignInButton calls handlePress from useAppleAuth', async () => {
+    mockAppleHandlePress.mockResolvedValue(undefined);
+    const result = LoginScreen({} as never);
+    const appleBtns = findAllByType(result, 'AppleSignInButton');
+    await (appleBtns[0].props.onPress as () => Promise<void>)();
+    expect(mockAppleHandlePress).toHaveBeenCalled();
   });
 });

--- a/mobile/src/screens/auth/__tests__/RegisterScreen.test.tsx
+++ b/mobile/src/screens/auth/__tests__/RegisterScreen.test.tsx
@@ -98,6 +98,16 @@ jest.mock('@/components/auth/GoogleSignInButton', () => ({
   GoogleSignInButton: (props: Record<string, unknown>) => require('react').createElement('GoogleSignInButton', props),
 }));
 
+const mockAppleHandlePress = jest.fn();
+const mockUseAppleAuth = jest.fn(() => ({ loading: false, handlePress: mockAppleHandlePress }));
+jest.mock('@/hooks/useAppleAuth', () => ({
+  useAppleAuth: (...args: unknown[]) => mockUseAppleAuth(...args),
+}));
+
+jest.mock('@/components/auth/AppleSignInButton', () => ({
+  AppleSignInButton: (props: Record<string, unknown>) => require('react').createElement('AppleSignInButton', props),
+}));
+
 // ---------------------------------------------------------------------------
 // Import under test (after mocks)
 // ---------------------------------------------------------------------------
@@ -125,6 +135,7 @@ describe('RegisterScreen', () => {
       )
     );
     mockUseGoogleAuth.mockImplementation(() => ({ loading: false, handlePress: mockHandlePress, disabled: false }));
+    mockUseAppleAuth.mockImplementation(() => ({ loading: false, handlePress: mockAppleHandlePress }));
   });
 
   it('returns a valid React element', () => {
@@ -258,5 +269,37 @@ describe('RegisterScreen', () => {
     const googleBtns = findAllByType(result, 'GoogleSignInButton');
     await (googleBtns[0].props.onPress as () => Promise<void>)();
     expect(mockHandlePress).toHaveBeenCalled();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Apple Sign-In tests
+  // ---------------------------------------------------------------------------
+
+  it('renders AppleSignInButton', () => {
+    const result = RegisterScreen({} as never);
+    const appleBtns = findAllByType(result, 'AppleSignInButton');
+    expect(appleBtns.length).toBeGreaterThan(0);
+  });
+
+  it('passes loading=false to AppleSignInButton by default', () => {
+    mockUseAppleAuth.mockReturnValue({ loading: false, handlePress: mockAppleHandlePress });
+    const result = RegisterScreen({} as never);
+    const appleBtns = findAllByType(result, 'AppleSignInButton');
+    expect(appleBtns[0].props.loading).toBe(false);
+  });
+
+  it('passes loading=true to AppleSignInButton when apple auth is loading', () => {
+    mockUseAppleAuth.mockReturnValue({ loading: true, handlePress: mockAppleHandlePress });
+    const result = RegisterScreen({} as never);
+    const appleBtns = findAllByType(result, 'AppleSignInButton');
+    expect(appleBtns[0].props.loading).toBe(true);
+  });
+
+  it('tapping AppleSignInButton calls handlePress from useAppleAuth', async () => {
+    mockAppleHandlePress.mockResolvedValue(undefined);
+    const result = RegisterScreen({} as never);
+    const appleBtns = findAllByType(result, 'AppleSignInButton');
+    await (appleBtns[0].props.onPress as () => Promise<void>)();
+    expect(mockAppleHandlePress).toHaveBeenCalled();
   });
 });

--- a/web/src/app/[locale]/privacy/page.tsx
+++ b/web/src/app/[locale]/privacy/page.tsx
@@ -152,6 +152,32 @@ function PrivacyEn({ t }: { t: TFn }) {
         <p>No advertising SDKs, analytics tools, or crash reporting services are embedded in the app.</p>
       </Section>
 
+      <Section title={t('sections.signInWithApple')}>
+        <p>
+          If you choose to sign in with Apple, Apple shares the following data with learnimo:
+        </p>
+        <ul className="ml-4 list-disc space-y-1">
+          <li>
+            <strong>Name</strong> (first sign-in only) — used to pre-fill your display name.
+          </li>
+          <li>
+            <strong>Email or private relay address</strong> — used to create and identify your
+            account, and for account recovery. Apple&apos;s private relay address
+            (e.g.&nbsp;<em>abc123@privaterelay.appleid.com</em>) functions like a real email for
+            all account purposes; learnimo cannot see your real Apple ID email when you use this
+            option.
+          </li>
+          <li>
+            <strong>Stable user identifier</strong> — a unique, persistent ID provided by Apple
+            that lets learnimo recognise your account across sign-ins without storing your Apple ID.
+          </li>
+        </ul>
+        <p>
+          learnimo uses this data solely to create and identify your account. It is not shared with
+          any third party.
+        </p>
+      </Section>
+
       <Section title={t('sections.yourRights')}>
         <ul className="ml-4 list-disc space-y-1">
           <li>
@@ -319,6 +345,35 @@ function PrivacyPtBR({ t }: { t: TFn }) {
         <p>
           Nenhum SDK de publicidade, ferramenta de análise ou serviço de relatório de falhas está
           integrado ao aplicativo.
+        </p>
+      </Section>
+
+      <Section title={t('sections.signInWithApple')}>
+        <p>
+          Se você optar por entrar com o Apple, a Apple compartilha os seguintes dados com o
+          learnimo:
+        </p>
+        <ul className="ml-4 list-disc space-y-1">
+          <li>
+            <strong>Nome</strong> (somente no primeiro login) — usado para preencher seu nome de
+            exibição.
+          </li>
+          <li>
+            <strong>E-mail ou endereço de retransmissão privada</strong> — usado para criar e
+            identificar sua conta e para recuperação de acesso. O endereço de retransmissão privada
+            da Apple (ex.:&nbsp;<em>abc123@privaterelay.appleid.com</em>) funciona como um e-mail
+            real para todos os fins de conta; o learnimo não tem acesso ao seu e-mail real do Apple
+            ID quando você usa essa opção.
+          </li>
+          <li>
+            <strong>Identificador de usuário estável</strong> — um ID único e persistente fornecido
+            pela Apple que permite ao learnimo reconhecer sua conta entre logins sem armazenar seu
+            Apple ID.
+          </li>
+        </ul>
+        <p>
+          O learnimo usa esses dados exclusivamente para criar e identificar sua conta. Eles não são
+          compartilhados com terceiros.
         </p>
       </Section>
 

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -391,6 +391,7 @@
       "howWeUse": "How we use your data",
       "storage": "Data storage",
       "thirdParties": "Third-party services",
+      "signInWithApple": "Sign in with Apple",
       "yourRights": "Your rights",
       "contact": "Contact"
     }

--- a/web/src/locales/pt-BR.json
+++ b/web/src/locales/pt-BR.json
@@ -391,6 +391,7 @@
       "howWeUse": "Como usamos seus dados",
       "storage": "Armazenamento de dados",
       "thirdParties": "Serviços de terceiros",
+      "signInWithApple": "Sign in with Apple",
       "yourRights": "Seus direitos",
       "contact": "Contato"
     }


### PR DESCRIPTION
## Summary

Implements Sign in with Apple (Guideline 4.8) — required for App Store resubmission. Mirrors the existing Google OAuth flow end-to-end: backend identity token verification, new mobile-auth endpoints, iOS-native button on auth screens, and privacy policy disclosure.

## Changes

- feat(backend): add apple_sub column to users (V23 migration)
- feat(backend): add Apple identity token verifier with JWK cache (pure-Java RS256, 15-min TTL, no new dependencies)
- feat(backend): add appleLogin and completeAppleSignup to AuthService
- feat(backend): add POST /auth/mobile/apple and /apple/complete endpoints
- feat(mobile): install expo-apple-authentication and register plugin
- feat(mobile): add appleLoginApi, useAppleAuth hook, and i18n keys
- feat(mobile): add AppleSignInButton, wire auth screens, add provider routing in ChooseHandleScreen
- docs(web): add Sign in with Apple data-handling section to privacy policy

## Testing

- [x] Backend unit tests: 495 passing, 0 failures
- [x] Backend integration tests: all passing (Testcontainers + PostgreSQL)
- [x] JaCoCo line coverage: 92.1% (threshold: 90%)
- [x] Mobile unit tests: 523 passing, 41 suites
- [x] Web production build: ✓
- [ ] On-device smoke test: pending Apple Developer Console setup (capability + `.p8` key + Railway env vars)

## Documentation

- [x] Spec updated to "Implemented" with architectural decisions and lessons learned
- [x] ROADMAP phase-1 updated (milestone 1.1.6)
- [x] OpenAPI annotations on new endpoints
- [x] Privacy policy updated (AC10)

## Prerequisites before merging / on-device verification

- Enable Sign in with Apple capability on App ID `net.learnimo.app` in Apple Developer Console
- Generate `.p8` key, record Team ID + Key ID
- Add `APPLE_TEAM_ID` and `APPLE_KEY_ID` to Railway env vars (config reference; token verification is JWKS-based and stateless)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>